### PR TITLE
Some fixes to address issue #9 Restricted Admin Mode & added check if the current IdentityReference is actually a SID

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -88,7 +88,7 @@ function Get-RestrictedAdminModeSetting {
     try {
         $RAM = Get-ItemProperty -Path $Path | Select-Object $RAMMode -ErrorAction Stop
         $Creds = Get-ItemProperty -Path $Path | Select-Object $OutboundCreds -ErrorAction Stop
-        if ($RAM.DisableRestrictedAdminMode -and $Creds.DisableRestrictedAdminOutboundCreds){
+        if ($RAM.DisableRestrictedAdminMode -eq '0' -and $Creds.DisableRestrictedAdminOutboundCreds -eq '1'){
             return $true
         } else {
             return $false

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -289,7 +289,11 @@ function Find-ESC1 {
     } | ForEach-Object {
         foreach($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            if ($Principal -match '^S-1') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
             if ( ($SID -notmatch $SafeUsers) -and ($entry.ActiveDirectoryRights -match 'ExtendedRight') ) {
                 $Issue = New-Object -TypeName pscustomobject
                 $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
@@ -328,7 +332,11 @@ function Find-ESC2 {
     } | ForEach-Object {
         foreach ($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            if ($Principal -match '^S-1') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
             if ( ($SID -notmatch $SafeUsers) -and ($entry.ActiveDirectoryRights -match 'ExtendedRight') ) {
                 $Issue = New-Object -TypeName pscustomobject
                 $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
@@ -364,7 +372,11 @@ function Find-ESC4 {
     )
     $ADCSObjects | ForEach-Object {
         $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($Principal -match '^S-1') {
+            $SID = $Principal
+        } else {
+            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        }
         if ( ($_.objectClass -eq 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
             $Issue = New-Object -TypeName pscustomobject
             $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
@@ -381,7 +393,11 @@ function Find-ESC4 {
         }
         foreach ($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            if ($Principal -match '^S-1') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
             if ( ($_.objectClass -eq 'pKICertificateTemplate') -and
                 ($SID -notmatch $SafeUsers) -and
                 ($entry.ActiveDirectoryRights -match $DangerousRights) ) {
@@ -417,7 +433,11 @@ function Find-ESC5 {
     )
     $ADCSObjects | ForEach-Object {
         $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($Principal -match '^S-1') {
+            $SID = $Principal
+        } else {
+            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        }
         if ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
             $Issue = New-Object -TypeName pscustomobject
             $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
@@ -434,7 +454,11 @@ function Find-ESC5 {
         }
         foreach ($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            if ($Principal -match '^S-1') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
             if ( ($_.objectClass -ne 'pKICertificateTemplate') -and
                 ($SID -notmatch $SafeUsers) -and
                 ($entry.ActiveDirectoryRights -match $DangerousRights) ) {


### PR DESCRIPTION
This pr consists of the following changes to resolve https://github.com/TrimarcJake/Locksmith/issues/9

- A new function `Get-RestrictedAdminModeSetting` with the purpose of checking the registry to see if Restricted Admin Mode (RAM) is enabled
  - The function checks for RAM in the following way:
	- if `HKLM:SYSTEM\CurrentControlSet\Control\Lsa\DisableRestrictedAdminMode` is set to 0 and `HKLM:SYSTEM\CurrentControlSet\Control\Lsa\DisableRestrictedAdminOutboundCreds` is set to 1 then RAM is enabled

- If RAM is found to be enabled, the script now warns you, tells you to use `-Credential` (a new argument added in this pr) and exits
  - `-Credential` is needed when RAM is enabled so credentials can be captured and passed to Get-AD cmdlets such as `Get-ADForest`, etc.

- A new argument has been added: `-Credential`
  - The intended usage is to add the following to the execution of Locksmith: `-Credential domain\username`

- Along with the new argument to the script as a whole, the -Credential option has been added to the following functions:
  - `Get-Target`
  - `Get-ADCSObject`
  - `Set-AdditionalCAProperty`
  - `Get-CAHostObject`

- When passing the `-Credential` option, `certutil.exe` no longer works. To remedy that, Locksmith has been updated to check the AuditFilter and EditFlags via the registry on the CA server using Invoke-Command

- Small fix related to https://github.com/TrimarcJake/Locksmith/issues/15 to check if the current `IdentityReference` is actually a SID and if it is, don't translate it to a SID, well because it's already a SID. :)

I think that's it. Please test and let me know if I broke anything or if anything doesn't work :)