### PR TITLE
Added checks for elevation and domain admin privs

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -110,28 +110,27 @@ function Test-IsElevated {
 }
 
 
-function Test-IsDomainAdmin {
+function Test-IsADAdmin {
     <#
     .SYNOPSIS
-        Tests if the current user has Domain Admin rights (or a comparable role).
+        Tests if the current user has administrative rights in Active Directory.
     .DESCRIPTION
-        This function returns True if the current user is a Domain Admin or False if not.
+        This function returns True if the current user is a Domain Admin (or equivalent) or False if not.
     .EXAMPLE
-        Test-IsDomainAdmin
+        Test-IsADAdmin
     .EXAMPLE
-        if (!(Test-IsDomainAdmin)) { Write-Host "You are not running with Domain Admin rights and will not be able to make certain changes." -ForeGroundColor Yellow }
+        if (!(Test-IsADAdmin)) { Write-Host "You are not running with Domain Admin rights and will not be able to make certain changes." -ForeGroundColor Yellow }
     #>
-    if (-not (
+    if (
         # Need to test to make sure this checks domain groups and not local groups, particularly for 'Administrators' (reference SID instead of name?).
          ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Domain Admin") -or
          ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Administrators") -or
          ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Enterprise Admins")
-        ) ) {
-        Write-Host "You do not have Domain Admin rights and will not be able to make certain changes." -ForegroundColor Yellow
-        Return $false
+       ) {
+        Return $true
     }
     else {
-        Return $true
+        Return $false
     }
 }
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -135,6 +135,27 @@ function Test-IsADAdmin {
 }
 
 
+function Test-IsLocalAccountSession {
+    <#
+    .SYNOPSIS
+        Tests if the current session is running under a local user account or a domain account.
+    .DESCRIPTION
+        This function returns True if the current session is a local user or False if it is a domain user.
+    .EXAMPLE
+        Test-IsLocalAccountSession
+    .EXAMPLE
+        if ( (Test-IsLocalAccountSession) ) { Write-Host "You are running this script under a local account." -ForeGroundColor Yellow }
+    #>
+        [CmdletBinding()]
+    
+        $CurrentSID = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        $LocalSIDs = (Get-LocalUser).SID.Value
+        if ($CurrentSID -in $LocalSIDs) {
+            Return $true
+        }
+    }
+
+
 function Get-RestrictedAdminModeSetting {
     $Path = 'HKLM:SYSTEM\CurrentControlSet\Control\Lsa'
     try {


### PR DESCRIPTION
Created functions to check for elevation (run as admin) and to check for domain admin privs. The DA privs check can be modified for specific AD group roles as needed. I will be performing further testing and potentially tweak the DA check to look up SID instead of group name. Future commits can make use of these functions.