### PR TITLE
Add support for rsat install on desktop os

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -636,10 +636,17 @@ if ($Credential) {
 
 # Check if ActiveDirectory PowerShell module is available, and attempt to install if not found
 if (-not(Get-Module -Name 'ActiveDirectory' -ListAvailable)) { 
-    # Attempt to install ActiveDirectory PowerShell module for Windows Server OSes, works with Windows Server 2012 R2 through Windows Server 2022
-    Install-WindowsFeature -Name RSAT-AD-PowerShell
-    #TODO: Check for Windows 10/11 OS (admin workstation, PAW) and install using Add-WindowsCapability cmdlet instead
+    $OS = (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
+    # 1 - workstation, 2 - domain controller, 3 - non-dc server
+    if ($OS -gt 1) {
+        # Attempt to install ActiveDirectory PowerShell module for Windows Server OSes, works with Windows Server 2012 R2 through Windows Server 2022
+        Install-WindowsFeature -Name RSAT-AD-PowerShell
+    } else {
+        # Attempt to install ActiveDirectory PowerShell module for Windows Desktop OSes
+        Add-WindowsCapability -Name Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0 -Online
+    }
 }
+
 
 Clear-Host
 $Logo


### PR DESCRIPTION
This is a very small PR to add support for installing RSAT tools on desktop operating systems. This was brought up in [Error "You cannot call a method on a null-valued expression."](https://github.com/TrimarcJake/Locksmith/issues/9)

The new code:

- Checks the operating system type using `(Get-CimInstance -ClassName Win32OperatingSystem).ProductType`
- If ProductType = 1 (a workstation OS), it will attempt to use `Add-WindowsCapability` to install RSAT tools
- If ProductType is greater than 1 it will attempt to use `Install-WindowsFeature`

Please let me know if you see any issues with this!