### PR TITLE
Added Error handling when there are no issues

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -834,7 +834,11 @@ Write-Host 'Identifying HTTP-based certificate enrollment interfaces...'
 
 [array]$AllIssues = $AuditingIssues + $ESC1 + $ESC2 + $ESC4 + $ESC5 + $ESC6 + $ESC8
 
-
+# If these are all empty = no issues found, exit
+if ((!$AuditingIssues) -and (!$ESC1) -and (!$ESC2) -and (!$ESC4) -and (!$ESC5) -and (!$ESC6) -and (!$ESC8) ) {
+    Write-Host "`n$(Get-Date) : No ADCS issues were found." -ForegroundColor Green
+    break
+}
 
 switch ($Mode) {
     0 { 


### PR DESCRIPTION
Added some basic error handling for when there are no issues at all. That way we can return an affirmative message that no issues were found. I included `Get-Date` because I thought it may be helpful for reporting/screenshotting purposes.