### PR TITLE
Add `-v` flag to certutil to read EditFlags

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -290,9 +290,9 @@ function Set-AdditionalCAProperty {
                 }
                 try {
                     if ($Credential) {
-                        $CertutilFlag = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock {param($CAFullName);certutil -config $CAFullName -getreg policy\EditFlags} -ArgumentList $CAFullName
+                        $CertutilFlag = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock {param($CAFullName);certutil -v -config $CAFullName -getreg policy\EditFlags} -ArgumentList $CAFullName
                     } else {
-                        $CertutilFlag = certutil -config $CAFullName -getreg policy\EditFlags
+                        $CertutilFlag = certutil -v -config $CAFullName -getreg policy\EditFlags
                     }
                 } catch {
                     $AuditFilter = 'Failure'


### PR DESCRIPTION
There are cases where certutil does not return that `EDITF_ATTRIBUTESUBJECTALTNAME2` is set without using the `-v` flag.

Seems like `EDITF_ATTRIBUTESUBJECTALTNAME2` can be "nested" within `EDITF_ENABLEDEFAULTSMIME`, causing `EDITF_ATTRIBUTESUBJECTALTNAME2` to not be shown.

This contradicts with the suggestion to use `certutil -config "CA_HOST\CA_NAME" -getreg "policy\EditFlags"` (without the `-v` flag) in the Certified Pre-Owned whitepaper.

See these outputs from a production CA environment using certutil with and without `-v` flag:

```
PS C:\Users\MyUser> certutil -getreg Policy\Editflags
HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration\MyCAInfra SUBCA4\PolicyModules\CertificateAuthority_MicrosoftDefault.Policy\EditFlags:

  EditFlags REG_DWORD = 11014e (1114446)
    EDITF_REQUESTEXTENSIONLIST -- 2
    EDITF_DISABLEEXTENSIONLIST -- 4
    EDITF_ADDOLDKEYUSAGE -- 8
    EDITF_BASICCONSTRAINTSCRITICAL -- 40 (64)
    EDITF_ENABLEAKIKEYID -- 100 (256)
    EDITF_ENABLEDEFAULTSMIME -- 10000 (65536)
    EDITF_ENABLECHASECLIENTDC -- 100000 (1048576)
CertUtil: -getreg command completed successfully.

PS C:\Users\MyUser> certutil -v -getreg Policy\Editflags
HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration\MyCAInfra SUBCA4\PolicyModules\CertificateAuthority_MicrosoftDefault.Policy\EditFlags:

  EditFlags REG_DWORD = 11014e (1114446)
      (EDITF_ENABLEREQUESTEXTENSIONS -- 1)
    EDITF_REQUESTEXTENSIONLIST -- 2
    EDITF_DISABLEEXTENSIONLIST -- 4
    EDITF_ADDOLDKEYUSAGE -- 8
      (EDITF_ADDOLDCERTTYPE -- 10 (16))
      (EDITF_ATTRIBUTEENDDATE -- 20 (32))
    EDITF_BASICCONSTRAINTSCRITICAL -- 40 (64)
      (EDITF_BASICCONSTRAINTSCA -- 80 (128))
    EDITF_ENABLEAKIKEYID -- 100 (256)
      (EDITF_ATTRIBUTECA -- 200 (512))
      (EDITF_IGNOREREQUESTERGROUP -- 400 (1024))
      (EDITF_ENABLEAKIISSUERNAME -- 800 (2048))
      (EDITF_ENABLEAKIISSUERSERIAL -- 1000 (4096))
      (EDITF_ENABLEAKICRITICAL -- 2000 (8192))
      (EDITF_SERVERUPGRADED -- 4000 (16384))
      (EDITF_ATTRIBUTEEKU -- 8000 (32768))
    EDITF_ENABLEDEFAULTSMIME -- 10000 (65536)
      (EDITF_EMAILOPTIONAL -- 20000 (131072))
      (EDITF_ATTRIBUTESUBJECTALTNAME2 -- 40000 (262144))
      (EDITF_ENABLELDAPREFERRALS -- 80000 (524288))
    EDITF_ENABLECHASECLIENTDC -- 100000 (1048576)
      (EDITF_AUDITCERTTEMPLATELOAD -- 200000 (2097152))
      (EDITF_DISABLEOLDOSCNUPN -- 400000 (4194304))
      (EDITF_DISABLELDAPPACKAGELIST -- 800000 (8388608))
      (EDITF_ENABLEUPNMAP -- 1000000 (16777216))
      (EDITF_ENABLEOCSPREVNOCHECK -- 2000000 (33554432))
      (EDITF_ENABLERENEWONBEHALFOF -- 4000000 (67108864))
CertUtil: -getreg command completed successfully.
```

Reference (German): https://www.gradenegger.eu/?p=1486