### PR TITLE
Speed up CA ping check

### DIFF
--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -20,7 +20,7 @@
                 $CAHostDistinguishedName = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Server $ForestGC ).DistinguishedName
                 $CAHostFQDN = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Properties DnsHostname -Server $ForestGC).DnsHostname
             }
-            $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet
+            $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
             if ($ping) {
                 try {
                     if ($Credential) {


### PR DESCRIPTION
Speed up the ping check for CAs by adding `-Count 1` to the `Test-Connection` cmdlet in Set-AdditionalCAProperty.ps1