### PR TITLE
Auditing-refactor-1

### DIFF
--- a/Private/Find-AuditingIssue.ps1
+++ b/Private/Find-AuditingIssue.ps1
@@ -9,25 +9,25 @@
         ($_.AuditFilter -ne '127')
     } | ForEach-Object {
         $Issue = New-Object -TypeName pscustomobject
-            $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Name -Value $_.Name -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name DistinguishedName -Value $_.DistinguishedName -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Forest' -Value $_.CanonicalName.split('/')[0] -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Name' -Value $_.Name -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'DistinguishedName' -Value $_.DistinguishedName -Force
         if ($_.AuditFilter -match 'CA Unavailable') {
-            $Issue | Add-Member -MemberType NoteProperty -Name Issue -Value $_.AuditFilter -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Fix -Value 'N/A' -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Revert -Value 'N/A' -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Technique -Value 'DETECT' -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Issue' -Value $_.AuditFilter -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Fix' -Value 'N/A' -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Revert' -Value 'N/A' -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Technique' -Value 'DETECT' -Force
         }
         else {
-            $Issue | Add-Member -MemberType NoteProperty -Name Issue -Value "Auditing is not fully enabled. Current value is $($_.AuditFilter)" -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Fix `
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Issue' -Value "Auditing is not fully enabled. Current value is $($_.AuditFilter)" -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Fix' `
                 -Value "certutil.exe -config `'$($_.CAFullname)`' -setreg `'CA\AuditFilter`' 127; Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Revert `
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Revert' `
                 -Value "certutil.exe -config $($_.CAFullname) -setreg CA\AuditFilter  $($_.AuditFilter); Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
-            $Issue | Add-Member -MemberType NoteProperty -Name Technique -Value 'DETECT' -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name 'Technique' -Value 'DETECT' -Force
         }
         $Severity = Set-Severity -Issue $Issue
-        $Issue | Add-Member -MemberType NoteProperty -Name Severity -Value $Severity
+        $Issue | Add-Member -MemberType NoteProperty -Name 'Severity' -Value $Severity
         $Issue
     }
 }

--- a/Private/Find-AuditingIssue.ps1
+++ b/Private/Find-AuditingIssue.ps1
@@ -9,9 +9,9 @@
         ($_.AuditFilter -ne '127')
     } | ForEach-Object {
         $Issue = New-Object -TypeName pscustomobject
-        $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
-        $Issue | Add-Member -MemberType NoteProperty -Name Name -Value $_.Name -Force
-        $Issue | Add-Member -MemberType NoteProperty -Name DistinguishedName -Value $_.DistinguishedName -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name Forest -Value $_.CanonicalName.split('/')[0] -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name Name -Value $_.Name -Force
+            $Issue | Add-Member -MemberType NoteProperty -Name DistinguishedName -Value $_.DistinguishedName -Force
         if ($_.AuditFilter -match 'CA Unavailable') {
             $Issue | Add-Member -MemberType NoteProperty -Name Issue -Value $_.AuditFilter -Force
             $Issue | Add-Member -MemberType NoteProperty -Name Fix -Value 'N/A' -Force

--- a/Private/Find-AuditingIssue.ps1
+++ b/Private/Find-AuditingIssue.ps1
@@ -21,9 +21,9 @@
         else {
             $Issue | Add-Member -MemberType NoteProperty -Name Issue -Value "Auditing is not fully enabled. Current value is $($_.AuditFilter)" -Force
             $Issue | Add-Member -MemberType NoteProperty -Name Fix `
-                -Value "certutil -config `'$($_.CAFullname)`' -setreg `'CA\AuditFilter`' 127; Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
+                -Value "certutil.exe -config `'$($_.CAFullname)`' -setreg `'CA\AuditFilter`' 127; Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
             $Issue | Add-Member -MemberType NoteProperty -Name Revert `
-                -Value "certutil -config $($_.CAFullname) -setreg CA\AuditFilter  $($_.AuditFilter); Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
+                -Value "certutil.exe -config $($_.CAFullname) -setreg CA\AuditFilter  $($_.AuditFilter); Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock { Get-Service -Name `'certsvc`' | Restart-Service -Force }" -Force
             $Issue | Add-Member -MemberType NoteProperty -Name Technique -Value 'DETECT' -Force
         }
         $Severity = Set-Severity -Issue $Issue


### PR DESCRIPTION
A few very minor suggested tweaks for readability or clarity.

Using quotes around property names intead of implicit stringification.

Indenting Add-Member lines under New-Object to show relationship in the code structure.

Added .exe extension to certutil for super clarity that an executable is being called.