### PR TITLE
Ad-module-check-1

### DIFF
--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -60,6 +60,26 @@
         [System.Management.Automation.PSCredential]$Credential
     )
 
+    # Check if ActiveDirectory PowerShell module is available, and attempt to install if not found
+    if (-not(Get-Module -Name 'ActiveDirectory' -ListAvailable)) {
+        if (Test-IsElevated) {
+            $OS = (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
+            # 1 - workstation, 2 - domain controller, 3 - non-dc server
+            if ($OS -gt 1) {
+                # Attempt to install ActiveDirectory PowerShell module for Windows Server OSes, works with Windows Server 2012 R2 through Windows Server 2022
+                Install-WindowsFeature -Name RSAT-AD-PowerShell
+            } else {
+                # Attempt to install ActiveDirectory PowerShell module for Windows Desktop OSes
+                Add-WindowsCapability -Name Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0 -Online
+            }
+        }
+        else {
+            Write-Warning -Message "The ActiveDirectory PowerShell module is required for Locksmith, but is not installed. Please launch an elevated PowerShell session to have this module installed for you automatically."
+            # The goal here is to exit the script without closing the PowerShell window. Need to test.
+            Return
+        }
+    }
+
     # Initial variables
     $Version = '2023.08'
     $AllDomainsCertPublishersSIDs = @()
@@ -125,19 +145,6 @@
         $Targets = Get-Target -Credential $Credential
     } else {
         $Targets = Get-Target
-    }
-
-    # Check if ActiveDirectory PowerShell module is available, and attempt to install if not found
-    if (-not(Get-Module -Name 'ActiveDirectory' -ListAvailable)) {
-        $OS = (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
-        # 1 - workstation, 2 - domain controller, 3 - non-dc server
-        if ($OS -gt 1) {
-            # Attempt to install ActiveDirectory PowerShell module for Windows Server OSes, works with Windows Server 2012 R2 through Windows Server 2022
-            Install-WindowsFeature -Name RSAT-AD-PowerShell
-        } else {
-            # Attempt to install ActiveDirectory PowerShell module for Windows Desktop OSes
-            Add-WindowsCapability -Name Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0 -Online
-        }
     }
 
     Write-Host "Gathering AD CS Objects from $($Targets)..."


### PR DESCRIPTION
Moved the ActiveDirectory module check above the first use of an AD cmdlet. 

Added a check for elevation (Test-IsElevated) before trying to install the module, if the module is not already installed. Notifies the user that the module is required and that they need to launch PowerShell as an administrator. 

Close the script (ideally without closing the PowerShell window) if missing the module and not elevated. Might need to change the Return statement to an Exit statement with a "press enter to exit" prompt.