### PR TITLE
First pass at ESC3 Condition 2 checking

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -11,7 +11,7 @@
     }
 }
 
-Update-Module -Name PSPublishModule -Scope CurrentUser
+Update-Module -Name PSPublishModule
 Import-Module -Name PSPublishModule -Force
 
 Build-Module -ModuleName 'Locksmith' {

--- a/Private/Find-ESC3Condition2.ps1
+++ b/Private/Find-ESC3Condition2.ps1
@@ -11,7 +11,8 @@
         ($_.pkiExtendedKeyUsage -match $ClientAuthEKU) -and
         ($_.'msPKI-Certificate-Name-Flag' -eq 1) -and
         ($_.'msPKI-Enrollment-Flag' -ne 2) -and
-        ( ($_.'msPKI-RA-Signature' -eq 0) -or ($null -eq $_.'msPKI-RA-Signature') )
+        ($_.'msPKI-RA-Application-Policies' -eq '1.3.6.1.4.1.311.20.2.1') -and
+        ( ($_.'msPKI-RA-Signature' -eq 1) )
     } | ForEach-Object {
         foreach ($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -169,7 +169,7 @@
     [array]$ESC1 = Find-ESC1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
     [array]$ESC2 = Find-ESC2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
     [array]$ESC3 = Find-ESC3Condition1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
-    # [array]$ESC3Condition2 = Find-ESC3Condition2 -ADCSObjects $ADCSObject -SafeUsers $SafeUsers
+    [array]$ESC3 += Find-ESC3Condition2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
 
     Write-Host 'Identifying AD CS template and other objects with poor access control...'
     [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners | Sort-Object Name


### PR DESCRIPTION
Here is a first crack at detecting ESC3 condition 2. The `Find-ESC3Condition2` function now:

1. Checks to see if `msPKI-RA-Application-Policies` OID is equal to `1.3.6.1.4.1.311.20.2.1` which should be for an Application Policy Issuance Requirement requiring the Certificate Request Agent Enhanced Key Usage (EKU). 
2. Checks to see if `msPKI-RA-Signature` is equal to `1`

Please test and let me know what you think. I created what I believe to be a vulnerable ESC3 condition 2 template and it does detect it.