### PR TITLE
Do not use other code within ScriptBlock that isn't related to config…

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -100,7 +100,7 @@ Build-Module -ModuleName 'Locksmith' {
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
-    New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
+    New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -UseWildcardForFunctions
 
@@ -117,6 +117,6 @@ Build-Module -ModuleName 'Locksmith' {
     New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Artefacts\Script" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
     New-ConfigurationArtefact -Type ScriptPacked -Enable -Path "$PSScriptRoot\..\Artefacts\ScriptPacked" -ArtefactName "Invoke-<ModuleName>.zip" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked"
-
-    Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-Locksmith.ps1" "$PSScriptRoot\..\"
 }
+
+Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-Locksmith.ps1" "$PSScriptRoot\..\"


### PR DESCRIPTION
Hi, 

The Build-Module scriptblock is executed at the very begining of the script. The main idea behind it is that each New-ConfigurationXXX command is basically creating hashtable with information what the module is supposed to do. This is why the order doesn't really matter there. It all gets executed in first few seconds when the script runs. 

THis also means using things like Copy-Item XXX for something that should be done after the script ends, should be done outside of the scriptblock. 

Using ImportRequiredModules is not really nessecary. 

Przemek