### PR TITLE
Removed duplicate RAM check

### DIFF
--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -160,11 +160,6 @@
         }
     }
 
-    if (!$Credential -and (Get-RestrictedAdminModeSetting)) {
-        Write-Warning "Restricted Admin Mode appears to be in place, re-run with the '-Credential domain\user' option"
-        break;
-    }
-
     if ($Credential) {
         $Targets = Get-Target -Credential $Credential
     } else {


### PR DESCRIPTION
Oh, look! In the last PR, I moved the Restricted Admin Mode check to the beginning of Invoke-Locksmith to avoid wasting an op's time if they were running RAM. Apparently I forgot to delete the original location of that check and left it in two places. Cleanup on aisle 12! (The check still exists [here](https://github.com/TrimarcJake/Locksmith/blob/2d54c5b1171f4a8c392e0b21a3a00eb7dd258149/Public/Invoke-Locksmith.ps1#L113).)

Resolves #82 