### PR TITLE
Add CA Host SIDs to $SafeUsers, Not Names

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2352,14 +2352,14 @@ function Invoke-Locksmith {
         Set-AdditionalCAProperty -ADCSObjects $ADCSObjects -Credential $Credential
         $ADCSObjects += Get-CAHostObject -ADCSObjects $ADCSObjects -Credential $Credential
         $CAHosts = Get-CAHostObject -ADCSObjects $ADCSObjects -Credential $Credential
-        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.Name }
+        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.objectSid }
     }
     else {
         $ADCSObjects = Get-ADCSObject -Targets $Targets
         Set-AdditionalCAProperty -ADCSObjects $ADCSObjects
         $ADCSObjects += Get-CAHostObject -ADCSObjects $ADCSObjects
         $CAHosts = Get-CAHostObject -ADCSObjects $ADCSObjects
-        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.Name }
+        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.objectSid }
     }
 
     if ( $Scans ) {

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -164,13 +164,13 @@
         Set-AdditionalCAProperty -ADCSObjects $ADCSObjects -Credential $Credential
         $ADCSObjects += Get-CAHostObject -ADCSObjects $ADCSObjects -Credential $Credential
         $CAHosts = Get-CAHostObject -ADCSObjects $ADCSObjects -Credential $Credential
-        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.Name }
+        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.objectSid }
     } else {
         $ADCSObjects = Get-ADCSObject -Targets $Targets
         Set-AdditionalCAProperty -ADCSObjects $ADCSObjects
         $ADCSObjects += Get-CAHostObject -ADCSObjects $ADCSObjects
         $CAHosts = Get-CAHostObject -ADCSObjects $ADCSObjects
-        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.Name }
+        $CAHosts | ForEach-Object { $SafeUsers += '|' + $_.objectSid }
     }
 
     if ( $Scans ) {


### PR DESCRIPTION
This PR updates the $SafeUsers generation section to use CA Host SIDs instead of Names because use SIDs almost everywhere instead of Names.