### PR TITLE
Updated ESC4 Remediations To Be More Flexible

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2246,12 +2246,14 @@ function Update-ESC4Remediation {
             [string]$Question = @"
 
 Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in the $($Issue.Name) template?"
-`t1. Enroll
-`t2. AutoEnroll
-`t3. Both
-`t4. Neither
-`t5. Unsure
-Enter your selection [1-5]
+
+  1. Enroll
+  2. AutoEnroll
+  3. Both
+  4. Neither
+  5. Unsure
+
+  Enter your selection [1-5]
 "@
             $RightsToRestore = Read-Host $Question
         }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2184,6 +2184,45 @@ function Test-IsRSATInstalled {
         $false
     }
 }
+function Update-ESC4Remediation {
+    <#
+    .SYNOPSIS
+        This function asks the user a set of questions to provide the most appropriate remediation for ESC4 issues.
+
+    .DESCRIPTION
+
+
+    .PARAMETER Issue
+
+
+    .PARAMETER Mode
+
+
+    .OUTPUTS
+        This function updates ESC4 remediations customized to the user's needs.
+
+    .EXAMPLE
+        $Target = Get-Target
+        $ADCSObjects = Get-ADCSObject -Target $Target
+        $DangerousRights = @('GenericAll', 'WriteProperty', 'WriteOwner', 'WriteDacl')
+        $SafeOwners = '-512$|-519$|-544$|-18$|-517$|-500$'
+        $SafeUsers = '-512$|-519$|-544$|-18$|-517$|-500$|-516$|-9$|-526$|-527$|S-1-5-10'
+        $SafeObjectTypes = '0e10c968-78fb-11d2-90d4-00c04f79dc55|a05b8cc2-17bc-4802-a710-e7c15ab866a2'
+        $ESC4Issues = Find-ESC4 -ADCSObjects $ADCSObjects -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeUsers $SafeUsers -SafeObjectTypes $SafeObjectTypes
+        Update-ESC4Remediation -ESC4Issues $ESC4Issues
+    #>
+    [CmdletBinding()]
+    param(
+        $ESC4Issues,
+        [Parameter(Mandatory = $true)]
+        [int]$Mode
+    )
+
+    $ESC4Issues | ForEach-Object -PipelineVariable Issue {
+        $_
+    }
+}
+
 function Invoke-Locksmith {
     <#
     .SYNOPSIS
@@ -2376,6 +2415,8 @@ function Invoke-Locksmith {
         $ESC6 = $Results['ESC6']
         $ESC8 = $Results['ESC8']
     }
+
+    
 
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2250,7 +2250,7 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object {
-        $_ | Format-List -Width 1000
+        $_
     }
 }
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2235,7 +2235,7 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object {
-        $_
+        $_ | Format-List -Width 1000
     }
 }
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -525,11 +525,14 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
                     HereFix               = @"
-$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
+`$Path = 'AD:$($_.DistinguishedName)'
+`$Principal = '$($Principal.Value)'
+`$ACL = Get-Acl -Path `$Path
 foreach ( `$ace in `$ACL.access ) {
-    if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
-        `$ACL.RemoveAccessRule(`$ace) | Out-Null
-        Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+    if ( (`$ace.IdentityReference.Value -like `$Principal ) -and
+        ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+            `$ACL.RemoveAccessRule(`$ace) | Out-Null
+            Set-Acl -Path `$Path -AclObject `$ACL
     }
 }
 "@
@@ -2429,8 +2432,6 @@ function Invoke-Locksmith {
         $ESC8 = $Results['ESC8']
     }
 
-    Update-ESC4Remediation -ESC4Issues $ESC4
-
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {
         Write-Host "`n$(Get-Date) : No ADCS issues were found.`n" -ForegroundColor Green
@@ -2488,6 +2489,9 @@ function Invoke-Locksmith {
     }
     Write-Host 'Thank you for using ' -NoNewline
     Write-Host "❤ Locksmith ❤`n" -ForegroundColor Magenta
+
+    Write-Host 'TEST STUFF'
+    Update-ESC4Remediation -ESC4Issues $ESC4
 }
 
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -524,6 +524,15 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     ActiveDirectoryRights = $entry.ActiveDirectoryRights
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
+                    HereFix               = @"
+`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+        Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+    }
+}
+"@
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'
                 }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -525,7 +525,7 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
                     HereFix               = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -511,9 +511,6 @@ function Find-ESC4 {
                 ($entry.ActiveDirectoryRights -match $DangerousRights) -and
                 ($entry.ObjectType -notmatch $SafeObjectTypes)
             ) {
-
-                $BlockFix = [scriptblock]::Create($HereFix)
-
                 $Issue = [pscustomobject]@{
                     Forest                = $_.CanonicalName.split('/')[0]
                     Name                  = $_.Name

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2265,14 +2265,14 @@ Enter your selection [1-5]
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
-`$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule $identity, $adRights, $accessType, $enrollGuid, $inheritanceType
+`$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
 foreach ( `$ace in `$ACL.access )
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-$ACL.AddAccessRule(`$NewRule)
-Set-Acl -Path `$Path -AclObject $ACL
+`$ACL.AddAccessRule(`$NewRule)
+Set-Acl -Path `$Path -AclObject `$ACL
 "@
             }
             2 {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -490,6 +490,12 @@ function Find-ESC4 {
                 DistinguishedName = $_.DistinguishedName
                 Issue             = "$($_.nTSecurityDescriptor.Owner) has Owner rights on this template"
                 Fix               = "`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`'); `$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; `$ACL.SetOwner(`$Owner); Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
+                HereFix           = @"
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
+`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL.SetOwner(`$Owner)
+Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+"@
                 Revert            = "`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`'); `$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; `$ACL.SetOwner(`$Owner); Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
                 Technique         = 'ESC4'
             }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -516,6 +516,20 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                 ($entry.ActiveDirectoryRights -match $DangerousRights) -and
                 ($entry.ObjectType -notmatch $SafeObjectTypes)
             ) {
+
+                $BlockFix = [scriptblock]@"
+`$Path = 'AD:$($_.DistinguishedName)'
+`$Principal = '$($Principal.Value)'
+`$ACL = Get-Acl -Path `$Path
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like `$Principal ) -and
+        ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+            `$ACL.RemoveAccessRule(`$ace) | Out-Null
+            Set-Acl -Path `$Path -AclObject `$ACL
+    }
+}
+"@
+
                 $Issue = [pscustomobject]@{
                     Forest                = $_.CanonicalName.split('/')[0]
                     Name                  = $_.Name
@@ -536,6 +550,7 @@ foreach ( `$ace in `$ACL.access ) {
     }
 }
 "@
+                    BlockFix              = $BlockFix
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'
                 }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2225,9 +2225,9 @@ function Update-ESC4Remediation {
 
     Write-Host $Issue.Issue
     $Admin = ''
-    while ( ($Admin -ne 'y') -and ($Admin -ne 'n') ) {
+    do {
         $Admin = Read-Host "Does $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
-    }
+    } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
         $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"
@@ -2532,9 +2532,6 @@ function Invoke-Locksmith {
     }
     Write-Host 'Thank you for using ' -NoNewline
     Write-Host "❤ Locksmith ❤`n" -ForegroundColor Magenta
-
-    Write-Host 'TEST STUFF'
-    Update-ESC4Remediation -ESC4Issues $ESC4
 }
 
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2228,6 +2228,7 @@ function Update-ESC4Remediation {
     $Header = "`n[!] ESC4 Issue detected in $($Issue.Name)"
     Write-Host $Header -ForegroundColor Yellow
     Write-Host $('-' * $Header.Length) -ForegroundColor Yellow
+    Write-Host "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template.`n"
     Write-Host 'To provide the most appropriate remediation for this issue, Locksmith will now ask you a few questions.'
 
     $Admin = ''
@@ -2236,7 +2237,7 @@ function Update-ESC4Remediation {
     } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
-        $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"
+        $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected."
         $Issue.Fix = "No immediate remediation required."
     }
     elseif ($Issue.Issue -match 'GenericAll') {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2239,7 +2239,7 @@ function Update-ESC4Remediation {
     }
     elseif ($Issue.Issue -match 'GenericAll') {
         $RightsToRestore = 0
-        while ($RightsToRestore -in 1..5) {
+        while ($RightsToRestore -notin 1..5) {
             [string]$Question = @"
 Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template? [1-5]"
 `t1. Enroll

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2216,8 +2216,8 @@ function Update-ESC4Remediation {
         $ESC4Issues
     )
 
-    $ESC4Issues | ForEach-Object -PipelineVariable Issue {
-        $Issue
+    $ESC4Issues | ForEach-Object {
+        $_
     }
 }
 
@@ -2414,7 +2414,7 @@ function Invoke-Locksmith {
         $ESC8 = $Results['ESC8']
     }
 
-    Update-ESC4Remediation -ESC4Issues $ES4
+    Update-ESC4Remediation -ESC4Issues $ESC4
 
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2416,7 +2416,7 @@ function Invoke-Locksmith {
         $ESC8 = $Results['ESC8']
     }
 
-    
+    Update-ESC4Remediation -ESC4Issues $ES4
 
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2257,9 +2257,9 @@ Enter your selection [1-5]
         switch ($RightsToRestore) {
             1 {
                 $Issue.Fix = @"
-`$Path = $($Issue.DistinguishedName)
+`$Path = '$($Issue.DistinguishedName)'
 `$ACL = Get-Acl -Path `$Path
-`$IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
+`$IdentityReference = [System.Principal.NTAccount]::New('$($Issue.IdentityReference)')
 `$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2276,13 +2276,70 @@ Set-Acl -Path `$Path -AclObject `$ACL
 "@
             }
             2 {
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
             3 {
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$EnrollRule)
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
             4 {
                 break 
             }
             5 {
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$EnrollRule)
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
         }
     }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2258,15 +2258,15 @@ Enter your selection [1-5]
         switch ($RightsToRestore) {
             1 {
                 $Issue.Fix = @"
-`$Path = '$($Issue.DistinguishedName)'
+`$Path = 'AD:$($Issue.DistinguishedName)'
 `$ACL = Get-Acl -Path `$Path
-`$IdentityReference = [System.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
 `$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
 `$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
-foreach ( `$ace in `$ACL.access )
+foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2217,7 +2217,7 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object -PipelineVariable Issue {
-        $_
+        $Issue
     }
 }
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2233,7 +2233,7 @@ function Update-ESC4Remediation {
 
     $Admin = ''
     do {
-        $Admin = Read-Host "`nDoes $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
+        $Admin = Read-Host "`nDoes $($Issue.IdentityReference) administer and/or maintain the $($Issue.Name) template? [y/n]"
     } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
@@ -2244,7 +2244,8 @@ function Update-ESC4Remediation {
         $RightsToRestore = 0
         while ($RightsToRestore -notin 1..5) {
             [string]$Question = @"
-Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template?"
+
+Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in the $($Issue.Name) template?"
 `t1. Enroll
 `t2. AutoEnroll
 `t3. Both
@@ -2304,7 +2305,7 @@ Set-Acl -Path `$Path -AclObject `$ACL
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
-`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$EnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
 `$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
@@ -2329,7 +2330,7 @@ Set-Acl -Path `$Path -AclObject `$ACL
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
-`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$EnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
 `$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2213,9 +2213,7 @@ function Update-ESC4Remediation {
     #>
     [CmdletBinding()]
     param(
-        $ESC4Issues,
-        [Parameter(Mandatory = $true)]
-        [int]$Mode
+        $ESC4Issues
     )
 
     $ESC4Issues | ForEach-Object -PipelineVariable Issue {

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -97,11 +97,14 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
                     HereFix               = @"
-$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
+`$Path = 'AD:$($_.DistinguishedName)'
+`$Principal = '$($Principal.Value)'
+`$ACL = Get-Acl -Path `$Path
 foreach ( `$ace in `$ACL.access ) {
-    if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
-        `$ACL.RemoveAccessRule(`$ace) | Out-Null
-        Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+    if ( (`$ace.IdentityReference.Value -like `$Principal ) -and
+        ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+            `$ACL.RemoveAccessRule(`$ace) | Out-Null
+            Set-Acl -Path `$Path -AclObject `$ACL
     }
 }
 "@

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -99,8 +99,6 @@
                 }
 
                 if ( ($Mode -ne 0) -and ($Mode -ne 1) ) {
-                    Write-Host "`n[!] ESC4 Issue detected in $($Issue.Name)" -ForegroundColor Yellow
-                    Write-Host 'To provide the most appropriate remediation for your environment, Locksmith will now ask you a few questions.'
                     Update-ESC4Remediation -Issue $Issue
                 }
 

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -97,6 +97,9 @@
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'
                 }
+
+                Write-Host '[!] ESC4 Issues have been detected. To provide the best remediation for your environment, Locksmith will now ask you a few questions.'
+                Update-ESC4Remediation -Issue $Issue
                 $Issue
             }
         }

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -47,7 +47,7 @@
         $SafeUsers,
         [Parameter(Mandatory = $true)]
         $SafeObjectTypes,
-        $Mode
+        [int]$Mode
     )
     $ADCSObjects | ForEach-Object {
         $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
@@ -95,7 +95,7 @@
                     Technique             = 'ESC4'
                 }
 
-                if ( ($Mode -ne 0) -and ($Mode -ne 1) ) {
+                if ( $Mode -in @(1,3,4) ) {
                     Update-ESC4Remediation -Issue $Issue
                 }
 

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -96,6 +96,15 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     ActiveDirectoryRights = $entry.ActiveDirectoryRights
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
+                    HereFix               = @"
+`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+        Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+    }
+}
+"@
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'
                 }

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -63,6 +63,12 @@
                 DistinguishedName     = $_.DistinguishedName
                 Issue                 = "$($_.nTSecurityDescriptor.Owner) has Owner rights on this template"
                 Fix                   = "`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`'); `$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; `$ACL.SetOwner(`$Owner); Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
+                HereFix               = @"
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
+`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL.SetOwner(`$Owner)
+Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+"@
                 Revert                = "`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`'); `$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; `$ACL.SetOwner(`$Owner); Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
                 Technique             = 'ESC4'
             }

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -98,8 +98,12 @@
                     Technique             = 'ESC4'
                 }
 
-                Write-Host '[!] ESC4 Issues have been detected. To provide the best remediation for your environment, Locksmith will now ask you a few questions.'
-                Update-ESC4Remediation -Issue $Issue
+                if ( ($Mode -ne 0) -and ($Mode -ne 1) ) {
+                    Write-Host "`n[!] ESC4 Issue detected in $($Issue.Name)" -ForegroundColor Yellow
+                    Write-Host 'To provide the most appropriate remediation for your environment, Locksmith will now ask you a few questions.'
+                    Update-ESC4Remediation -Issue $Issue
+                }
+
                 $Issue
             }
         }

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -83,9 +83,6 @@
                 ($entry.ActiveDirectoryRights -match $DangerousRights) -and
                 ($entry.ObjectType -notmatch $SafeObjectTypes)
                 ) {
-
-                $BlockFix = [scriptblock]::Create($HereFix)
-
                 $Issue = [pscustomobject]@{
                     Forest                = $_.CanonicalName.split('/')[0]
                     Name                  = $_.Name

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -97,7 +97,7 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
                     HereFix               = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -89,7 +89,7 @@ Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
                 ($entry.ObjectType -notmatch $SafeObjectTypes)
                 ) {
 
-                $BlockFix = [scriptblock]@"
+                $HereFix = @"
 `$Path = 'AD:$($_.DistinguishedName)'
 `$Principal = '$($Principal.Value)'
 `$ACL = Get-Acl -Path `$Path
@@ -100,7 +100,8 @@ foreach ( `$ace in `$ACL.access ) {
             Set-Acl -Path `$Path -AclObject `$ACL
     }
 }
-"@
+"@              
+                $BlockFix = [scriptblock]::Create($HereFix)
 
                 $Issue = [pscustomobject]@{
                     Forest                = $_.CanonicalName.split('/')[0]
@@ -110,18 +111,7 @@ foreach ( `$ace in `$ACL.access ) {
                     ActiveDirectoryRights = $entry.ActiveDirectoryRights
                     Issue                 = "$($entry.IdentityReference) has $($entry.ActiveDirectoryRights) rights on this template"
                     Fix                   = "`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'; foreach ( `$ace in `$ACL.access ) { if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) { `$ACL.RemoveAccessRule(`$ace) | Out-Null ; Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL } }"
-                    HereFix               = @"
-`$Path = 'AD:$($_.DistinguishedName)'
-`$Principal = '$($Principal.Value)'
-`$ACL = Get-Acl -Path `$Path
-foreach ( `$ace in `$ACL.access ) {
-    if ( (`$ace.IdentityReference.Value -like `$Principal ) -and
-        ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
-            `$ACL.RemoveAccessRule(`$ace) | Out-Null
-            Set-Acl -Path `$Path -AclObject `$ACL
-    }
-}
-"@
+                    HereFix               = $HereFix
                     BlockFix              = $BlockFix
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'

--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -44,7 +44,8 @@ function Invoke-Scans {
     # Could split Scans and PromptMe into separate parameter sets.
     [Parameter()]
         [ValidateSet('Auditing','ESC1','ESC2','ESC3','ESC4','ESC5','ESC6','ESC8','All','PromptMe')]
-        [array]$Scans = 'All'
+        [array]$Scans = 'All',
+        [int]$Mode
     )
 
     # Is this needed?
@@ -114,7 +115,7 @@ function Invoke-Scans {
             [array]$ESC3 = Find-ESC3Condition1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
             [array]$ESC3 += Find-ESC3Condition2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers
             Write-Host 'Identifying AD CS template and other objects with poor access control (ESC4)...'
-            [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes
+            [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes -Mode $Mode
             Write-Host 'Identifying AD CS template and other objects with poor access control (ESC5)...'
             [array]$ESC5 = Find-ESC5 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes
             Write-Host 'Identifying Certificate Authorities configured with dangerous flags (ESC6)...'

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -33,6 +33,7 @@ function Update-ESC4Remediation {
     $Header = "`n[!] ESC4 Issue detected in $($Issue.Name)"
     Write-Host $Header -ForegroundColor Yellow
     Write-Host $('-' * $Header.Length) -ForegroundColor Yellow
+    Write-Host "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template.`n"
     Write-Host 'To provide the most appropriate remediation for this issue, Locksmith will now ask you a few questions.'
 
     $Admin = ''
@@ -41,7 +42,7 @@ function Update-ESC4Remediation {
     } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
-        $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"
+        $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected."
         $Issue.Fix = "No immediate remediation required."
     } elseif ($Issue.Issue -match 'GenericAll') {
         $RightsToRestore = 0

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -80,13 +80,68 @@ Set-Acl -Path `$Path -AclObject `$ACL
 "@
             }
             2 {
-
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
             3 {
-
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$EnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$EnrollRule)
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
             4 { break }
             5 {
+                $Issue.Fix = @"
+`$Path = 'AD:$($Issue.DistinguishedName)'
+`$ACL = Get-Acl -Path `$Path
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
+`$AutoEnrollGuid = [System.Guid]::New('a05b8cc2-17bc-4802-a710-e7c15ab866a2')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$EnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
+`$AutoEnrollRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$AutoEnrollGuid, `$InheritanceType
+foreach ( `$ace in `$ACL.access ) {
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+`$ACL.AddAccessRule(`$EnrollRule)
+`$ACL.AddAccessRule(`$AutoEnrollRule)
+Set-Acl -Path `$Path -AclObject `$ACL
+"@
             }
         }
     }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -27,9 +27,7 @@ function Update-ESC4Remediation {
     #>
     [CmdletBinding()]
     param(
-        $ESC4Issues,
-        [Parameter(Mandatory = $true)]
-        [int]$Mode
+        $ESC4Issues
     )
 
     $ESC4Issues | ForEach-Object -PipelineVariable Issue {

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -31,6 +31,6 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object -PipelineVariable Issue {
-        $_
+        $Issue
     }
 }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -1,0 +1,38 @@
+function Update-ESC4Remediation.ps1 {
+    <#
+    .SYNOPSIS
+        This function asks the user a set of questions to provide the most appropriate remediation for ESC4 issues.
+
+    .DESCRIPTION
+
+
+    .PARAMETER Issue
+
+
+    .PARAMETER Mode
+
+
+    .OUTPUTS
+        This function updates ESC4 remediations customized to the user's needs.
+
+    .EXAMPLE
+        $Target = Get-Target
+        $ADCSObjects = Get-ADCSObject -Target $Target
+        $DangerousRights = @('GenericAll', 'WriteProperty', 'WriteOwner', 'WriteDacl')
+        $SafeOwners = '-512$|-519$|-544$|-18$|-517$|-500$'
+        $SafeUsers = '-512$|-519$|-544$|-18$|-517$|-500$|-516$|-9$|-526$|-527$|S-1-5-10'
+        $SafeObjectTypes = '0e10c968-78fb-11d2-90d4-00c04f79dc55|a05b8cc2-17bc-4802-a710-e7c15ab866a2'
+        $ESC4Issues = Find-ESC4 -ADCSObjects $ADCSObjects -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeUsers $SafeUsers -SafeObjectTypes $SafeObjectTypes
+        Update-ESC4Remediation -ESC4Issues $ESC4Issues
+    #>
+    [CmdletBinding()]
+    param(
+        $ESC4Issues,
+        [Parameter(Mandatory = $true)]
+        [int]$Mode
+    )
+
+    $ESC4Issues | ForEach-Object -PipelineVariable Issue {
+        $_
+    }
+}

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -38,7 +38,7 @@ function Update-ESC4Remediation {
 
     $Admin = ''
     do {
-        $Admin = Read-Host "`nDoes $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
+        $Admin = Read-Host "`nDoes $($Issue.IdentityReference) administer and/or maintain the $($Issue.Name) template? [y/n]"
     } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
@@ -48,7 +48,8 @@ function Update-ESC4Remediation {
         $RightsToRestore = 0
         while ($RightsToRestore -notin 1..5) {
             [string]$Question = @"
-Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template?"
+
+Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in the $($Issue.Name) template?"
 `t1. Enroll
 `t2. AutoEnroll
 `t3. Both

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -61,9 +61,9 @@ Enter your selection [1-5]
         switch ($RightsToRestore) {
             1 {
                 $Issue.Fix = @"
-`$Path = $($Issue.DistinguishedName)
+`$Path = '$($Issue.DistinguishedName)'
 `$ACL = Get-Acl -Path `$Path
-`$IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
+`$IdentityReference = [System.Principal.NTAccount]::New('$($Issue.IdentityReference)')
 `$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -41,7 +41,7 @@ function Update-ESC4Remediation {
         $Issue.Fix = "No immediate remediation required."
     } elseif ($Issue.Issue -match 'GenericAll') {
         $RightsToRestore = 0
-        while ($RightsToRestore -in 1..5) {
+        while ($RightsToRestore -notin 1..5) {
             [string]$Question = @"
 Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template? [1-5]"
 `t1. Enroll

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -30,7 +30,7 @@ function Update-ESC4Remediation {
         $ESC4Issues
     )
 
-    $ESC4Issues | ForEach-Object -PipelineVariable Issue {
-        $Issue
+    $ESC4Issues | ForEach-Object {
+        $_
     }
 }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -30,10 +30,14 @@ function Update-ESC4Remediation {
         $Issue
     )
 
-    Write-Host $Issue.Issue
+    $Header = "`n[!] ESC4 Issue detected in $($Issue.Name)"
+    Write-Host $Header -ForegroundColor Yellow
+    Write-Host $('-' * $Header.Length) -ForegroundColor Yellow
+    Write-Host 'To provide the most appropriate remediation for this issue, Locksmith will now ask you a few questions.'
+
     $Admin = ''
     do {
-        $Admin = Read-Host "Does $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
+        $Admin = Read-Host "`nDoes $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
     } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
@@ -43,12 +47,13 @@ function Update-ESC4Remediation {
         $RightsToRestore = 0
         while ($RightsToRestore -notin 1..5) {
             [string]$Question = @"
-Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template? [1-5]"
+Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template?"
 `t1. Enroll
 `t2. AutoEnroll
 `t3. Both
 `t4. Neither
 `t5. Unsure
+Enter your selection [1-5]
 "@
             $RightsToRestore = Read-Host $Question
         }
@@ -58,7 +63,7 @@ Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this templa
                 $Issue.Fix = @"
 `$Path = $($Issue.DistinguishedName)
 `$ACL = Get-Acl -Path `$Path
-`IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
+`$IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
 `$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -32,9 +32,9 @@ function Update-ESC4Remediation {
 
     Write-Host $Issue.Issue
     $Admin = ''
-    while ( ($Admin -ne 'y') -and ($Admin -ne 'n') ) {
+    do {
         $Admin = Read-Host "Does $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
-    }
+    } while ( ($Admin -ne 'y') -and ($Admin -ne 'n') )
 
     if ($Admin -eq 'y') {
         $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -69,14 +69,14 @@ Enter your selection [1-5]
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
-`$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule $identity, $adRights, $accessType, $enrollGuid, $inheritanceType
+`$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
 foreach ( `$ace in `$ACL.access )
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-$ACL.AddAccessRule(`$NewRule)
-Set-Acl -Path `$Path -AclObject $ACL
+`$ACL.AddAccessRule(`$NewRule)
+Set-Acl -Path `$Path -AclObject `$ACL
 "@
             }
             2 {

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -62,15 +62,15 @@ Enter your selection [1-5]
         switch ($RightsToRestore) {
             1 {
                 $Issue.Fix = @"
-`$Path = '$($Issue.DistinguishedName)'
+`$Path = 'AD:$($Issue.DistinguishedName)'
 `$ACL = Get-Acl -Path `$Path
-`$IdentityReference = [System.Principal.NTAccount]::New('$($Issue.IdentityReference)')
+`$IdentityReference = [System.Security.Principal.NTAccount]::New('$($Issue.IdentityReference)')
 `$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
 `$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
 `$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
 `$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
 `$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `$IdentityReference, `$ExtendedRight, `$AccessType, `$EnrollGuid, `$InheritanceType
-foreach ( `$ace in `$ACL.access )
+foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -1,4 +1,4 @@
-function Update-ESC4Remediation.ps1 {
+function Update-ESC4Remediation {
     <#
     .SYNOPSIS
         This function asks the user a set of questions to provide the most appropriate remediation for ESC4 issues.

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -50,12 +50,14 @@ function Update-ESC4Remediation {
             [string]$Question = @"
 
 Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in the $($Issue.Name) template?"
-`t1. Enroll
-`t2. AutoEnroll
-`t3. Both
-`t4. Neither
-`t5. Unsure
-Enter your selection [1-5]
+
+  1. Enroll
+  2. AutoEnroll
+  3. Both
+  4. Neither
+  5. Unsure
+
+  Enter your selection [1-5]
 "@
             $RightsToRestore = Read-Host $Question
         }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -31,6 +31,6 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object {
-        $_ | Format-List -Width 1000
+        $_
     }
 }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -27,10 +27,63 @@ function Update-ESC4Remediation {
     #>
     [CmdletBinding()]
     param(
-        $ESC4Issues
+        $Issue
     )
 
-    $ESC4Issues | ForEach-Object {
-        $_
+    Write-Host $Issue.Issue
+    $Admin = ''
+    while ( ($Admin -ne 'y') -and ($Admin -ne 'n') ) {
+        $Admin = Read-Host "Does $($Issue.IdentityReference) administer and/or maintain this template? [y/n]"
+    }
+
+    if ($Admin -eq 'y') {
+        $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"
+        $Issue.Fix = "No immediate remediation required."
+    } else {
+        if ($Issue.Issue -match 'GenericAll') {
+            $RightsToRestore = 0
+            while ($RightsToRestore -in 1..5) {
+                [string]$Question = @"
+Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template? [1-5]"
+`t1. Enroll
+`t2. AutoEnroll
+`t3. Both
+`t4. Neither
+`t5. Unsure
+"@
+                $RightsToRestore = Read-Host $Question
+            }
+
+            switch ($RightsToRestore) {
+                1 {
+                    $Issue.Fix = @"
+`$Path = $($Issue.DistinguishedName)
+`$ACL = Get-Acl -Path `$Path
+`IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
+`$EnrollGuid = [System.Guid]::New('0e10c968-78fb-11d2-90d4-00c04f79dc55')
+`$ExtendedRight = [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight
+`$AccessType = [System.Security.AccessControl.AccessControlType]::Allow
+`$InheritanceType = [System.DirectoryServices.ActiveDirectorySecurityInheritance]::All
+`$NewRule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule $identity, $adRights, $accessType, $enrollGuid, $inheritanceType
+foreach ( `$ace in `$ACL.access )
+    if ( (`$ace.IdentityReference.Value -like '$($Issue.IdentityReference)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
+        `$ACL.RemoveAccessRule(`$ace) | Out-Null
+    }
+}
+$ACL.AddAccessRule(`$NewRule)
+Set-Acl -Path `$Path -AclObject $ACL
+"@
+                }
+                2 {
+
+                }
+                3 {
+
+                }
+                4 { break }
+                5 {
+                }
+            }
+        }
     }
 }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -31,6 +31,6 @@ function Update-ESC4Remediation {
     )
 
     $ESC4Issues | ForEach-Object {
-        $_
+        $_ | Format-List -Width 1000
     }
 }

--- a/Private/Update-ESC4Remediation.ps1
+++ b/Private/Update-ESC4Remediation.ps1
@@ -39,11 +39,10 @@ function Update-ESC4Remediation {
     if ($Admin -eq 'y') {
         $Issue.Issue = "$($Issue.IdentityReference) has $($Issue.ActiveDirectoryRights) rights on this template, but this is expected"
         $Issue.Fix = "No immediate remediation required."
-    } else {
-        if ($Issue.Issue -match 'GenericAll') {
-            $RightsToRestore = 0
-            while ($RightsToRestore -in 1..5) {
-                [string]$Question = @"
+    } elseif ($Issue.Issue -match 'GenericAll') {
+        $RightsToRestore = 0
+        while ($RightsToRestore -in 1..5) {
+            [string]$Question = @"
 Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this template? [1-5]"
 `t1. Enroll
 `t2. AutoEnroll
@@ -51,12 +50,12 @@ Does $($Issue.IdentityReference) need to Enroll and/or AutoEnroll in this templa
 `t4. Neither
 `t5. Unsure
 "@
-                $RightsToRestore = Read-Host $Question
-            }
+            $RightsToRestore = Read-Host $Question
+        }
 
-            switch ($RightsToRestore) {
-                1 {
-                    $Issue.Fix = @"
+        switch ($RightsToRestore) {
+            1 {
+                $Issue.Fix = @"
 `$Path = $($Issue.DistinguishedName)
 `$ACL = Get-Acl -Path `$Path
 `IdentityReference = [System.Principal.NTAccount]::New($($Issue.IdentityReference))
@@ -73,16 +72,15 @@ foreach ( `$ace in `$ACL.access )
 $ACL.AddAccessRule(`$NewRule)
 Set-Acl -Path `$Path -AclObject $ACL
 "@
-                }
-                2 {
+            }
+            2 {
 
-                }
-                3 {
+            }
+            3 {
 
-                }
-                4 { break }
-                5 {
-                }
+            }
+            4 { break }
+            5 {
             }
         }
     }

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -188,7 +188,7 @@
             $ESC8           = $Results['ESC8']
     }
 
-    
+    Update-ESC4Remediation -ESC4Issues $ES4
 
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -188,6 +188,8 @@
             $ESC8           = $Results['ESC8']
     }
 
+    
+
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {
         Write-Host "`n$(Get-Date) : No ADCS issues were found.`n" -ForegroundColor Green

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -188,8 +188,6 @@
             $ESC8           = $Results['ESC8']
     }
 
-    Update-ESC4Remediation -ESC4Issues $ESC4
-
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {
         Write-Host "`n$(Get-Date) : No ADCS issues were found.`n" -ForegroundColor Green
@@ -245,4 +243,7 @@
     }
     Write-Host 'Thank you for using ' -NoNewline
     Write-Host "❤ Locksmith ❤`n" -ForegroundColor Magenta
+
+    Write-Host 'TEST STUFF'
+    Update-ESC4Remediation -ESC4Issues $ESC4
 }

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -188,7 +188,7 @@
             $ESC8           = $Results['ESC8']
     }
 
-    Update-ESC4Remediation -ESC4Issues $ES4
+    Update-ESC4Remediation -ESC4Issues $ESC4
 
     # If these are all empty = no issues found, exit
     if ($null -eq $Results) {

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -243,7 +243,4 @@
     }
     Write-Host 'Thank you for using ' -NoNewline
     Write-Host "❤ Locksmith ❤`n" -ForegroundColor Magenta
-
-    Write-Host 'TEST STUFF'
-    Update-ESC4Remediation -ESC4Issues $ESC4
 }

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -175,7 +175,7 @@
 
     if ( $Scans ) {
     # If the Scans parameter was used, Invoke-Scans with the specified checks.
-        $Results = Invoke-Scans -Scans $Scans
+        $Results = Invoke-Scans -Scans $Scans -Mode $Mode
             # Re-hydrate the findings arrays from the Results hash table
             $AllIssues      = $Results['AllIssues']
             $AuditingIssues = $Results['AuditingIssues']


### PR DESCRIPTION
This should close #126 by doing the following:

1. If the Mode is not 0 or 2 AND an ESC4 is detected, Locksmith will ask a couple simple questions to determine the best course of remediation.
- Does the principal administer this template?
- (If the granted rights are GenericAll) Does the principal need to Enroll/AutoEnroll?
2. The answers to those questions will update the "Fix" attribute with one of the following options:
- Marks the issue as not needing remediation.
- Leaves basic remediation unchanged
- Removes GenericAll and restores Enroll
- Removes GenericAll and restores AutoEnroll
- Removes GenericAll and restores Enroll + AutoEnroll
- Removes GenericAll and restores nothing