### PR TITLE
Require Microsoft.PowerShell.Security module

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -44,6 +44,7 @@ Build-Module -ModuleName 'Locksmith' {
         'Microsoft.PowerShell.Utility'
         'Microsoft.PowerShell.LocalAccounts'
         'Microsoft.PowerShell.Management'
+        'Microsoft.PowerShell.Security'
         'CimCmdlets'
         'Dism'
     )

--- a/Locksmith.psd1
+++ b/Locksmith.psd1
@@ -11,12 +11,12 @@
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
-            ExternalModuleDependencies = @('ActiveDirectory', 'ServerManager', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.LocalAccounts', 'Microsoft.PowerShell.Management', 'CimCmdlets', 'Dism')
+            ExternalModuleDependencies = @('ActiveDirectory', 'ServerManager', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.LocalAccounts', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'CimCmdlets', 'Dism')
             IconUri                    = 'https://raw.githubusercontent.com/TrimarcJake/Locksmith/main/Images/locksmith.ico'
             ProjectUri                 = 'https://github.com/TrimarcJake/Locksmith'
             Tags                       = @('Windows', 'Locksmith', 'CA', 'PKI', 'ActiveDirectory', 'CertificateServices', 'ADCS')
         }
     }
-    RequiredModules      = @('ActiveDirectory', 'ServerManager', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.LocalAccounts', 'Microsoft.PowerShell.Management', 'CimCmdlets', 'Dism')
+    RequiredModules      = @('ActiveDirectory', 'ServerManager', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.LocalAccounts', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'CimCmdlets', 'Dism')
     RootModule           = 'Locksmith.psm1'
 }


### PR DESCRIPTION
Fixes #143 (affects PowerShell 7) by listing Microsoft.PowerShell.Security in the required modules.