### PR TITLE
Bug Fix for SafeUsers when groups are empty

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2679,7 +2679,8 @@ function Invoke-Locksmith {
             $SafeUsers += '|' + $user
         }
     }
-
+    $SafeUsers = $SafeUsers.Replace('||','|')
+    
     if ($Credential) {
         $Targets = Get-Target -Credential $Credential
     }


### PR DESCRIPTION
When using the += adding an empty value still increments the count of the object and therefore when adding the pipe between entries it will result in a double pipe. 

This double pipe causes problems in the Find-ESC1.ps1 script when the $SafeUsers variable is evaluated causing the "($SID -notmatch $SafeUsers)" to wrongfully fail. This results in false-negative reporting for any checks using this this type of logic. 

The existence of the empty item in $SafeUsers will always match on any $SID and therefore no templates will ever report as being misconfigured.