### PR TITLE
Use placeholder for version in script source

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,9 @@
-﻿if (Get-Module -Name 'PSPublishModule' -ListAvailable) {
+﻿param (
+    # A CalVer string if you need to manually override the default yyyy.M version string.
+    [string]$CalVer
+)
+
+if (Get-Module -Name 'PSPublishModule' -ListAvailable) {
     Write-Information 'PSPublishModule is installed.'
 } else {
     Write-Information 'PSPublishModule is not installed. Attempting installation.'
@@ -17,7 +22,7 @@ Import-Module -Name PSPublishModule -Force
 Build-Module -ModuleName 'Locksmith' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
-        ModuleVersion        = (Get-Date -Format yyyy.M)
+        ModuleVersion        = if ($Calver) {$CalVer} else {(Get-Date -Format yyyy.M)}
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = 'b1325b42-8dc4-4f17-aa1f-dcb5984ca14a'
         Author               = 'Jake Hildreth'

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -35,6 +35,13 @@ Build-Module -ModuleName 'Locksmith' {
     }
     New-ConfigurationManifest @Manifest
 
+    # See [PR26](https://github.com/EvotecIT/PSPublishModule/pull/26) for notes about using placeholders and
+    # built-in placeholders for common module metadata.
+    # New-ConfigurationPlaceHolder -CustomReplacement @(
+    #     @{ Find = '{CustomName}'; Replace = 'SpecialCase' }
+    #     @{ Find = '{CustomVersion}'; Replace = '1.0.0' }
+    # )
+
     # Add standard module dependencies (directly, but can be used with loop as well)
     #New-ConfigurationModule -Type RequiredModule -Name 'PSSharedGoods' -Guid 'Auto' -Version 'Latest'
 

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -76,7 +76,7 @@
         [System.Management.Automation.PSCredential]$Credential
     )
 
-    $Version = '2024.8'
+    $Version = '<ModuleVersion>'
     $LogoPart1 = @"
     _       _____  _______ _     _ _______ _______ _____ _______ _     _
     |      |     | |       |____/  |______ |  |  |   |      |    |_____|


### PR DESCRIPTION
The latest release of PSPublishModule adds supports for code placeholders that get replaced during the build process. Placeholders and their replacements can be defined in .\Build\Build-Module.ps1 and there are also a number of predefined placeholders.

This PR takes advantage of the predefined placeholder <ModuleVersion> which gets automatically replaced with the ModuleVersion value from the manifest.

I also added a $CalVer parameter to Build-Module.ps1 so a version can be manually specified (uses `.\Build\Build-Module.ps1 -CalVer '2024.8.15'`). If this parameter is not used, the build will automatically be versioned by `(Get-Date -format yyyy.M)`.