### PR TITLE
Fix ESC8 False Negatives

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1965,10 +1965,7 @@ function Set-AdditionalCAProperty {
 
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
-            [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { 
-                Write-Host $_.Matches[0].Value 
-                $_.Matches[0].Value 
-            }
+            [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { $_.Matches[0].Value }
             [string]$CAFullName = "$($_.dNSHostName)\$($_.Name)"
             $CAHostname = $_.dNSHostName.split('.')[0]
             if ($Credential) {
@@ -1992,8 +1989,7 @@ function Set-AdditionalCAProperty {
                         $Request.Timeout = 3000
 
                         try {
-                            Write-Host "Testing URL: $URL"
-                            $Request.GetResponse()
+                            $Request.GetResponse() | Out-Null
                             $CAEnrollmentEndpoint += $URL
                         }
                         catch {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -2010,11 +2010,8 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                     try {
                         $FullURL = "https$URL"
                         $Request = [System.Net.WebRequest]::Create($FullURL)
-                        $Cache = [System.Net.CredentialCache]::New()
-                        $Cache.Add([System.Uri]::new($FullURL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
-                        $Request.Credentials = $Cache
+                       
                         $Request.GetResponse() | Out-Null
-                        # $CAEnrollmentEndpoint += $FullURL
                         $CAEnrollmentEndpoint += @{
                             'URL'  = $FullURL
                             'Auth' = $Auth
@@ -2026,10 +2023,9 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                             $FullURL = "https$URL"
                             $Request = [System.Net.WebRequest]::Create($FullURL)
                             $Cache = [System.Net.CredentialCache]::New()
-                            $Cache.Add([System.Uri]::new($FullURL), $Auth, [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                            $Cache.Add([System.Uri]::new($FullURL), 'Negotiate', [System.Net.CredentialCache]::DefaultNetworkCredentials)
                             $Request.Credentials = $Cache
                             $Request.GetResponse() | Out-Null
-                            # $CAEnrollmentEndpoint += $FullURL
                             $CAEnrollmentEndpoint += @{
                                 'URL'  = $FullURL
                                 'Auth' = $Auth

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1978,7 +1978,6 @@ function Set-AdditionalCAProperty {
                 foreach ($type in @('http', 'https')) {
                     foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
                         $URL = "$($type)://$($_.dNSHostName)/$directory"
-<<<<<<< HEAD
                         $Request = [System.Net.WebRequest]::Create($URL)
                         $Cache = New-Object System.Net.CredentialCache
                         $Cache.Add([System.Uri]::new($URL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
@@ -1992,12 +1991,6 @@ function Set-AdditionalCAProperty {
                         }
                         catch {
                         }
-=======
-                        Write-Host "Testing URL: $URL"
-                        Invoke-WebRequest $URL | Out-Null
-                        $?
-                        Read-Host 'Press any key to Continue'
->>>>>>> 12588d80e393bb04b0755fed5c6bd082ef16b02c
                     }
                 }
                 try {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1989,17 +1989,12 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
             }
             $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
             if ($ping) {
-                # foreach ($type in @('http', 'https')) {
-                # if ($type -eq 'http') {
-                #     $Auth = 'NTLM'
-                # } elseif ($type -eq 'https') {
-                #     $Auth = 'Negotiate'
-                # }
+                
                 foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
                     $URL = "://$($_.dNSHostName)/$directory"
-                        
+                    
 
-                        
+                    
 
                     try {
                         $FullURL = "http$URL"
@@ -2025,7 +2020,6 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                         }
                     }
                 }
-                # }
                 try {
                     if ($Credential) {
                         $CertutilAudit = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock { param($CAFullName); certutil -config $CAFullName -getreg CA\AuditFilter } -ArgumentList $CAFullName

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1149,7 +1149,7 @@ function Get-RestrictedAdminModeSetting {
         Retrieves the current configuration of the Restricted Admin Mode setting.
 
     .DESCRIPTION
-        This script retrieves the current configuration of the Restricted Admin Mode setting from the registry.
+        This script retrieves the current configuration of the Restricted Admin Mode setting from the registry. 
         It checks if the DisableRestrictedAdmin value is set to '0' and the DisableRestrictedAdminOutboundCreds value is set to '1'.
         If both conditions are met, it returns $true; otherwise, it returns $false.
 
@@ -1957,12 +1957,14 @@ function Set-AdditionalCAProperty {
         $ForestGC
     )
 
+    begin {
+        $CAEnrollmentEndpoint = @()
+    }
+
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
-            [string]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { $_.Matches[0].Value }
             [string]$CAFullName = "$($_.dNSHostName)\$($_.Name)"
             $CAHostname = $_.dNSHostName.split('.')[0]
-            # $CAName = $_.Name
             if ($Credential) {
                 $CAHostDistinguishedName = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Server $ForestGC -Credential $Credential).DistinguishedName
                 $CAHostFQDN = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Properties DnsHostname -Server $ForestGC -Credential $Credential).DnsHostname
@@ -1973,6 +1975,24 @@ function Set-AdditionalCAProperty {
             }
             $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
             if ($ping) {
+                foreach ($type in @('http', 'https')) {
+                    foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
+                        $URL = "$($type)://$($_.dNSHostName)/$directory"
+                        $Request = [System.Net.WebRequest]::Create($URL)
+                        $Cache = New-Object System.Net.CredentialCache
+                        $Cache.Add([System.Uri]::new($URL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                        
+                        $Request.Credentials = $Cache
+                        $Request.Timeout = 3000
+
+                        try {
+                            $Response = $Request.GetResponse()
+                            $CAEnrollmentEndpoint += $URL
+                        }
+                        catch {
+                        }
+                    }
+                }
                 try {
                     if ($Credential) {
                         $CertutilAudit = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock { param($CAFullName); certutil -config $CAFullName -getreg CA\AuditFilter } -ArgumentList $CAFullName
@@ -2788,7 +2808,7 @@ function Invoke-Locksmith {
         }
     }
     Write-Host 'Thank you for using ' -NoNewline
-    Write-Host "❤  Locksmith ❤`n" -ForegroundColor Magenta
+    Write-Host "❤ Locksmith ❤`n" -ForegroundColor Magenta
 }
 
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -854,20 +854,22 @@ function Find-ESC8 {
         $ADCSObjects | Where-Object {
             $_.CAEnrollmentEndpoint
         } | ForEach-Object {
-            $Issue = [pscustomobject]@{
-                Forest               = $_.CanonicalName.split('/')[0]
-                Name                 = $_.Name
-                DistinguishedName    = $_.DistinguishedName
-                CAEnrollmentEndpoint = $_.CAEnrollmentEndpoint
-                Issue                = 'HTTP enrollment is enabled.'
-                Fix                  = '[TODO]'
-                Revert               = '[TODO]'
-                Technique            = 'ESC8'
+            foreach ($endpoint in $_.CAEnrollmentEndpoint) {
+                $Issue = [pscustomobject]@{
+                    Forest               = $_.CanonicalName.split('/')[0]
+                    Name                 = $_.Name
+                    DistinguishedName    = $_.DistinguishedName
+                    CAEnrollmentEndpoint = $endpoint
+                    Issue                = 'HTTP enrollment is enabled.'
+                    Fix                  = '[TODO]'
+                    Revert               = '[TODO]'
+                    Technique            = 'ESC8'
+                }
+                if ($endpoint -match '^https') {
+                    $Issue.Issue = 'HTTPS enrollment is enabled.'
+                }
+                $Issue
             }
-            if ($_.CAEnrollmentEndpoint -match '^https') {
-                $Issue.Issue = 'HTTPS enrollment is enabled.'
-            }
-            $Issue
         }
     }
 }

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -535,12 +535,14 @@ function Find-ESC4 {
         [int]$Mode
     )
     $ADCSObjects | ForEach-Object {
-        $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        if ($Principal -match '^(S-1|O:)') {
-            $SID = $Principal
-        }
-        else {
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($_.Name -ne '' -and $null -ne $_.Name) {
+            $Principal = [System.Security.Principal.NTAccount]::New($_.nTSecurityDescriptor.Owner)
+            if ($Principal -match '^(S-1|O:)') {
+                $SID = $Principal
+            }
+            else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
         }
 
         if ( ($_.objectClass -eq 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
@@ -685,12 +687,14 @@ function Find-ESC5 {
         $SafeObjectTypes
     )
     $ADCSObjects | ForEach-Object {
-        $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        if ($Principal -match '^(S-1|O:)') {
-            $SID = $Principal
-        }
-        else {
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($_.Name -ne '' -and $null -ne $_.Name) {
+            $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
+            if ($Principal -match '^(S-1|O:)') {
+                $SID = $Principal
+            }
+            else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
         }
 
         if ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1961,6 +1961,17 @@ function Set-AdditionalCAProperty {
 
     begin {
         $CAEnrollmentEndpoint = @()
+        $code = @"
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+public class TrustAllCertsPolicy : ICertificatePolicy {
+    public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate, WebRequest request, int certificateProblem) {
+        return true;
+    }
+}
+"@
+        Add-Type -TypeDefinition $code -Language CSharp
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
     }
 
     process {
@@ -1978,24 +1989,43 @@ function Set-AdditionalCAProperty {
             }
             $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
             if ($ping) {
-                foreach ($type in @('http', 'https')) {
-                    foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
-                        $URL = "$($type)://$($_.dNSHostName)/$directory"
-                        $Request = [System.Net.WebRequest]::Create($URL)
-                        $Cache = [System.Net.CredentialCache]::New()
-                        $Cache.Add([System.Uri]::new($URL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                # foreach ($type in @('http', 'https')) {
+                # if ($type -eq 'http') {
+                #     $Auth = 'NTLM'
+                # } elseif ($type -eq 'https') {
+                #     $Auth = 'Negotiate'
+                # }
+                foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
+                    $URL = "://$($_.dNSHostName)/$directory"
                         
+
+                        
+
+                    try {
+                        $FullURL = "http$URL"
+                        $Request = [System.Net.WebRequest]::Create($FullURL)
+                        $Cache = [System.Net.CredentialCache]::New()
+                        $Cache.Add([System.Uri]::new($FullURL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
                         $Request.Credentials = $Cache
                         $Request.Timeout = 3000
-
+                        $Request.GetResponse() | Out-Null
+                        $CAEnrollmentEndpoint += $FullURL
+                    }
+                    catch {
                         try {
+                            $FullURL = "https$URL"
+                            $Request = [System.Net.WebRequest]::Create($FullURL)
+                            $Cache = [System.Net.CredentialCache]::New()
+                            $Cache.Add([System.Uri]::new($FullURL), 'Negotiate', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                            $Request.Credentials = $Cache
                             $Request.GetResponse() | Out-Null
-                            $CAEnrollmentEndpoint += $URL
+                            $CAEnrollmentEndpoint += $FullURL
                         }
                         catch {
                         }
                     }
                 }
+                # }
                 try {
                     if ($Credential) {
                         $CertutilAudit = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock { param($CAFullName); certutil -config $CAFullName -getreg CA\AuditFilter } -ArgumentList $CAFullName

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -75,11 +75,13 @@
         [int]$Mode
     )
     $ADCSObjects | ForEach-Object {
-        $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        if ($Principal -match '^(S-1|O:)') {
-            $SID = $Principal
-        } else {
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($_.Name -ne '' -and $null -ne $_.Name) {
+            $Principal = [System.Security.Principal.NTAccount]::New($_.nTSecurityDescriptor.Owner)
+            if ($Principal -match '^(S-1|O:)') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
         }
 
         if ( ($_.objectClass -eq 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {

--- a/Private/Find-ESC5.ps1
+++ b/Private/Find-ESC5.ps1
@@ -73,11 +73,13 @@
         $SafeObjectTypes
     )
     $ADCSObjects | ForEach-Object {
-        $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
-        if ($Principal -match '^(S-1|O:)') {
-            $SID = $Principal
-        } else {
-            $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+        if ($_.Name -ne '' -and $null -ne $_.Name) {
+            $Principal = New-Object System.Security.Principal.NTAccount($_.nTSecurityDescriptor.Owner)
+            if ($Principal -match '^(S-1|O:)') {
+                $SID = $Principal
+            } else {
+                $SID = ($Principal.Translate([System.Security.Principal.SecurityIdentifier])).Value
+            }
         }
 
         if ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {

--- a/Private/Find-ESC8.ps1
+++ b/Private/Find-ESC8.ps1
@@ -48,7 +48,7 @@
                     Revert               = '[TODO]'
                     Technique            = 'ESC8'
                 }
-                if ($endpoint -match '^https') {
+                if ($endpoint -match 'https:') {
                     $Issue.Issue = 'HTTPS enrollment is enabled.'
                 }
                 $Issue

--- a/Private/Find-ESC8.ps1
+++ b/Private/Find-ESC8.ps1
@@ -37,20 +37,22 @@
         $ADCSObjects | Where-Object {
             $_.CAEnrollmentEndpoint
         } | ForEach-Object {
-            $Issue = [pscustomobject]@{
-                Forest               = $_.CanonicalName.split('/')[0]
-                Name                 = $_.Name
-                DistinguishedName    = $_.DistinguishedName
-                CAEnrollmentEndpoint = $_.CAEnrollmentEndpoint
-                Issue                = 'HTTP enrollment is enabled.'
-                Fix                  = '[TODO]'
-                Revert               = '[TODO]'
-                Technique            = 'ESC8'
+            foreach ($endpoint in $_.CAEnrollmentEndpoint) {
+                $Issue = [pscustomobject]@{
+                    Forest               = $_.CanonicalName.split('/')[0]
+                    Name                 = $_.Name
+                    DistinguishedName    = $_.DistinguishedName
+                    CAEnrollmentEndpoint = $endpoint
+                    Issue                = 'HTTP enrollment is enabled.'
+                    Fix                  = '[TODO]'
+                    Revert               = '[TODO]'
+                    Technique            = 'ESC8'
+                }
+                if ($endpoint -match '^https') {
+                    $Issue.Issue = 'HTTPS enrollment is enabled.'
+                }
+                $Issue
             }
-            if ($_.CAEnrollmentEndpoint -match '^https') {
-                $Issue.Issue = 'HTTPS enrollment is enabled.'
-            }
-            $Issue
         }
     }
 }

--- a/Private/Find-ESC8.ps1
+++ b/Private/Find-ESC8.ps1
@@ -42,14 +42,23 @@
                     Forest               = $_.CanonicalName.split('/')[0]
                     Name                 = $_.Name
                     DistinguishedName    = $_.DistinguishedName
-                    CAEnrollmentEndpoint = $endpoint
-                    Issue                = 'HTTP enrollment is enabled.'
-                    Fix                  = '[TODO]'
+                    CAEnrollmentEndpoint = $endpoint.URL
+                    AuthType             = $endpoint.Auth
+                    Issue                = 'An HTTP enrollment endpoint is available.'
+                    Fix                  = @'
+Disable HTTP access and enforce HTTPS.
+Enable EPA.
+Disable NTLM authentication (if possible.)
+'@
                     Revert               = '[TODO]'
                     Technique            = 'ESC8'
                 }
-                if ($endpoint -match 'https:') {
-                    $Issue.Issue = 'HTTPS enrollment is enabled.'
+                if ($endpoint.URL -match '^https:') {
+                    $Issue.Issue = 'An HTTPS enrollment endpoint is available.'
+                    $Issue.Fix   = @'
+Ensure EPA is enabled.
+Disable NTLM authentication (if possible.)
+'@
                 }
                 $Issue
             }

--- a/Private/Format-Result.ps1
+++ b/Private/Format-Result.ps1
@@ -50,7 +50,7 @@
             }
             1 {
                 if ($Issue.Technique -eq 'ESC8') {
-                    $Issue | Format-List Technique, Name, DistinguishedName, CAEnrollmentEndpoint, Issue, Fix
+                    $Issue | Format-List Technique, Name, DistinguishedName, CAEnrollmentEndpoint, AuthType, Issue, Fix
                 } else {
                     $Issue | Format-List Technique, Name, DistinguishedName, Issue, Fix
                     if(($Issue.Technique -eq "DETECT" -or $Issue.Technique -eq "ESC6") -and (Get-RestrictedAdminModeSetting)){

--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -41,6 +41,10 @@
 
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
+            [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { 
+                Write-Host $_.Matches[0].Value 
+                $_.Matches[0].Value 
+            }
             [string]$CAFullName = "$($_.dNSHostName)\$($_.Name)"
             $CAHostname = $_.dNSHostName.split('.')[0]
             if ($Credential) {
@@ -56,14 +60,15 @@
                     foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
                         $URL = "$($type)://$($_.dNSHostName)/$directory"
                         $Request = [System.Net.WebRequest]::Create($URL)
-                        $Cache = New-Object System.Net.CredentialCache
+                        $Cache = [System.Net.CredentialCache]::New()
                         $Cache.Add([System.Uri]::new($URL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
                         
                         $Request.Credentials = $Cache
                         $Request.Timeout = 3000
 
                         try {
-                            $Response = $Request.GetResponse()
+                            Write-Host "Testing URL: $URL"
+                            $Request.GetResponse()
                             $CAEnrollmentEndpoint += $URL
                         }
                         catch {}

--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -41,10 +41,7 @@
 
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
-            [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { 
-                Write-Host $_.Matches[0].Value 
-                $_.Matches[0].Value 
-            }
+            [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { $_.Matches[0].Value }
             [string]$CAFullName = "$($_.dNSHostName)\$($_.Name)"
             $CAHostname = $_.dNSHostName.split('.')[0]
             if ($Credential) {
@@ -67,8 +64,7 @@
                         $Request.Timeout = 3000
 
                         try {
-                            Write-Host "Testing URL: $URL"
-                            $Request.GetResponse()
+                            $Request.GetResponse() | Out-Null
                             $CAEnrollmentEndpoint += $URL
                         }
                         catch {}

--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -72,11 +72,8 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                     try {
                         $FullURL = "https$URL"
                         $Request = [System.Net.WebRequest]::Create($FullURL)
-                        $Cache = [System.Net.CredentialCache]::New()
-                        $Cache.Add([System.Uri]::new($FullURL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
-                        $Request.Credentials = $Cache
+                       
                         $Request.GetResponse() | Out-Null
-                        # $CAEnrollmentEndpoint += $FullURL
                         $CAEnrollmentEndpoint += @{
                             'URL'  = $FullURL
                             'Auth' = $Auth
@@ -87,10 +84,9 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                             $FullURL = "https$URL"
                             $Request = [System.Net.WebRequest]::Create($FullURL)
                             $Cache = [System.Net.CredentialCache]::New()
-                            $Cache.Add([System.Uri]::new($FullURL), $Auth, [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                            $Cache.Add([System.Uri]::new($FullURL), 'Negotiate', [System.Net.CredentialCache]::DefaultNetworkCredentials)
                             $Request.Credentials = $Cache
                             $Request.GetResponse() | Out-Null
-                            # $CAEnrollmentEndpoint += $FullURL
                             $CAEnrollmentEndpoint += @{
                                 'URL'  = $FullURL
                                 'Auth' = $Auth

--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -52,6 +52,23 @@
             }
             $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
             if ($ping) {
+                foreach ($type in @('http', 'https')) {
+                    foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
+                        $URL = "$($type)://$($_.dNSHostName)/$directory"
+                        $Request = [System.Net.WebRequest]::Create($URL)
+                        $Cache = New-Object System.Net.CredentialCache
+                        $Cache.Add([System.Uri]::new($URL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                        
+                        $Request.Credentials = $Cache
+                        $Request.Timeout = 3000
+
+                        try {
+                            $Response = $Request.GetResponse()
+                            $CAEnrollmentEndpoint += $URL
+                        }
+                        catch {}
+                    }
+                }
                 try {
                     if ($Credential) {
                         $CertutilAudit = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock { param($CAFullName); certutil -config $CAFullName -getreg CA\AuditFilter } -ArgumentList $CAFullName

--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -53,6 +53,30 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
             [array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { $_.Matches[0].Value }
+            foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
+                $URL = "://$($_.dNSHostName)/$directory"
+                try {
+                    $FullURL = "http$URL"
+                    $Request = [System.Net.WebRequest]::Create($FullURL)
+                    $Cache = [System.Net.CredentialCache]::New()
+                    $Cache.Add([System.Uri]::new($FullURL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                    $Request.Credentials = $Cache
+                    $Request.Timeout = 3000
+                    $Request.GetResponse() | Out-Null
+                    $CAEnrollmentEndpoint += $FullURL
+                } catch {
+                    try {
+                        $FullURL = "https$URL"
+                        $Request = [System.Net.WebRequest]::Create($FullURL)
+                        $Cache = [System.Net.CredentialCache]::New()
+                        $Cache.Add([System.Uri]::new($FullURL), 'Negotiate', [System.Net.CredentialCache]::DefaultNetworkCredentials)
+                        $Request.Credentials = $Cache
+                        $Request.GetResponse() | Out-Null
+                        $CAEnrollmentEndpoint += $FullURL
+                    } catch {
+                    }
+                }
+            }
             [string]$CAFullName = "$($_.dNSHostName)\$($_.Name)"
             $CAHostname = $_.dNSHostName.split('.')[0]
             if ($Credential) {
@@ -63,36 +87,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
                 $CAHostFQDN = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Properties DnsHostname -Server $ForestGC).DnsHostname
             }
             $ping = Test-Connection -ComputerName $CAHostFQDN -Quiet -Count 1
-            if ($ping) {
-                
-                foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
-                    $URL = "://$($_.dNSHostName)/$directory"
-                    
-
-                    
-
-                    try {
-                        $FullURL = "http$URL"
-                        $Request = [System.Net.WebRequest]::Create($FullURL)
-                        $Cache = [System.Net.CredentialCache]::New()
-                        $Cache.Add([System.Uri]::new($FullURL), 'NTLM', [System.Net.CredentialCache]::DefaultNetworkCredentials)
-                        $Request.Credentials = $Cache
-                        $Request.Timeout = 3000
-                        $Request.GetResponse() | Out-Null
-                        $CAEnrollmentEndpoint += $FullURL
-                    } catch {
-                        try {
-                            $FullURL = "https$URL"
-                            $Request = [System.Net.WebRequest]::Create($FullURL)
-                            $Cache = [System.Net.CredentialCache]::New()
-                            $Cache.Add([System.Uri]::new($FullURL), 'Negotiate', [System.Net.CredentialCache]::DefaultNetworkCredentials)
-                            $Request.Credentials = $Cache
-                            $Request.GetResponse() | Out-Null
-                            $CAEnrollmentEndpoint += $FullURL
-                        } catch {
-                        }
-                    }
-                }
+            if ($ping) { 
                 try {
                     if ($Credential) {
                         $CertutilAudit = Invoke-Command -ComputerName $CAHostname -Credential $Credential -ScriptBlock { param($CAFullName); certutil -config $CAFullName -getreg CA\AuditFilter } -ArgumentList $CAFullName


### PR DESCRIPTION
This resolves #153 by replacing attribute-based ESC8 checks with web request-based checks to validate the endpoint is online.

Also improved the `Fix` attribute from `[TODO]` to something actually meaningful.

Tested in 5 labs and 2 production environments so far. All 7 environments return the same results except @techspence 's lab :suspect: 