### PR TITLE
Implement the OutputPath variable

### DIFF
--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -72,7 +72,16 @@
         [Parameter()]
             [ValidateSet('Auditing','ESC1','ESC2','ESC3','ESC4','ESC5','ESC6','ESC8','All','PromptMe')]
             [array]$Scans = 'All',
-        [string]$OutputPath = (Get-Location).Path,
+        
+        # The directory to save the output in (defaults to the current working directory).
+        [Parameter()]
+            [ValidateScript({(Test-Path -Path $_ -PathType Container)},
+                ErrorMessage = "{0} is not a valid directory path."
+            )]
+            [string]$OutputPath = $PWD,
+
+        # The credential to use for working with ADCS.
+        [Parameter()]
         [System.Management.Automation.PSCredential]$Credential
     )
 
@@ -109,6 +118,9 @@
     }
 
     ### Initial variables
+    # For output filenames
+    [string]$FilePrefix = "Locksmith $(Get-Date -format 'yyyy-MM-dd hh-mm-ss') "
+
     # Extended Key Usages for client authentication. A requirement for ESC1
     $ClientAuthEKUs = '1\.3\.6\.1\.5\.5\.7\.3\.2|1\.3\.6\.1\.5\.2\.3\.4|1\.3\.6\.1\.4\.1\.311\.20\.2\.2|2\.5\.29\.37\.0'
 
@@ -270,7 +282,7 @@
             Format-Result $ESC8 '1'
         }
         2 {
-            $Output = 'ADCSIssues.CSV'
+            $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSIssues.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
                 $AllIssues | Select-Object Forest, Technique, Name, Issue | Export-Csv -NoTypeInformation $Output
@@ -280,7 +292,7 @@
             }
         }
         3 {
-            $Output = 'ADCSRemediation.CSV'
+            $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSRemediation.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
                 $AllIssues | Select-Object Forest, Technique, Name, DistinguishedName, Issue, Fix | Export-Csv -NoTypeInformation $Output

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -75,9 +75,7 @@
         
         # The directory to save the output in (defaults to the current working directory).
         [Parameter()]
-            [ValidateScript({(Test-Path -Path $_ -PathType Container)},
-                ErrorMessage = "{0} is not a valid directory path."
-            )]
+            [ValidateScript({Test-Path -Path $_ -PathType Container})]
             [string]$OutputPath = $PWD,
 
         # The credential to use for working with ADCS.
@@ -119,7 +117,7 @@
 
     ### Initial variables
     # For output filenames
-    [string]$FilePrefix = "Locksmith $(Get-Date -format 'yyyy-MM-dd hh-mm-ss') "
+    [string]$FilePrefix = "Locksmith $(Get-Date -format 'yyyy-MM-dd hh-mm-ss')"
 
     # Extended Key Usages for client authentication. A requirement for ESC1
     $ClientAuthEKUs = '1\.3\.6\.1\.5\.5\.7\.3\.2|1\.3\.6\.1\.5\.2\.3\.4|1\.3\.6\.1\.4\.1\.311\.20\.2\.2|2\.5\.29\.37\.0'


### PR DESCRIPTION
Implements the OutputPath variable that was previously defined. Allows the op to specify a path to store the Locksmith CSV files in. (Defaults to the current working directory.) Also prefixes the CSVs with "Locksmith" and the current timestamp.