### PR TITLE
Improve ESC3 Condition 2 detections

### DIFF
--- a/Private/Find-ESC3Condition2.ps1
+++ b/Private/Find-ESC3Condition2.ps1
@@ -33,10 +33,9 @@
     $ADCSObjects | Where-Object {
         ($_.objectClass -eq 'pKICertificateTemplate') -and
         ($_.pkiExtendedKeyUsage -match $ClientAuthEKU) -and
-        ($_.'msPKI-Certificate-Name-Flag' -band 1) -and
         !($_.'msPKI-Enrollment-Flag' -band 2) -and
-        ($_.'msPKI-RA-Application-Policies' -eq '1.3.6.1.4.1.311.20.2.1') -and
-        ( ($_.'msPKI-RA-Signature' -eq 1) )
+        ($_.'msPKI-RA-Application-Policies' -match '1.3.6.1.4.1.311.20.2.1') -and
+        ($_.'msPKI-RA-Signature' -eq 1)
     } | ForEach-Object {
         foreach ($entry in $_.nTSecurityDescriptor.Access) {
             $Principal = New-Object System.Security.Principal.NTAccount($entry.IdentityReference)


### PR DESCRIPTION
The msPKI-Certiticate-Name-Flag isn't important for this check and was causing false negatives. FIXED!