### PR TITLE
Uncommenting AllIssues in Return Value for Invoke-Scans.ps1

### DIFF
--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -150,7 +150,7 @@ function Invoke-Scans {
 
     # Return a hash table of array names (keys) and arrays (values) so they can be directly referenced with other functions
     return @{
-        # AllIssues      = $AllIssues
+        AllIssues      = $AllIssues
         AuditingIssues = $AuditingIssues
         ESC1           = $ESC1
         ESC2           = $ESC2


### PR DESCRIPTION

### Expected Behavior:

When using Mode 2 or Mode 3, a CSV with matching results to Mode 0 or Mode 1.

### Observed Behavior:
The .CSV file is created successfully, however it is empty. 

### Technical Issue:

In the .\Private\Invoke-Scans.ps1 file, the 'AllIssues' Key/Value pair in the Results Hashtable was commented out. This is breaking the output to CSV for Modes 2 and 3, as they both use this Key to generate the CSV:

```
Private\Invoke-Scans.ps1:152
    return @{
        # AllIssues      = $AllIssues
        AuditingIssues = $AuditingIssues
        ESC1           = $ESC1
        ESC2           = $ESC2
        ESC3           = $ESC3
        ESC4           = $ESC4
        ESC5           = $ESC5
        ESC6           = $ESC6
        ESC8           = $ESC8
        ESC11          = $ESC11
        ESC13          = $ESC13
        ESC15          = $ESC15
    }
}
```

```
Public\Invoke-Locksmith.ps1:331       
        2 {
            $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSIssues.CSV"
            Write-Host "Writing AD CS issues to $Output..."
            try {
                $AllIssues | Select-Object Forest, Technique, Name, Issue | Export-Csv -NoTypeInformation $Output
                Write-Host "$Output created successfully!`n"
            } catch {
                Write-Host 'Ope! Something broke.'
            }
        }
        3 {
            $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSRemediation.CSV"
            Write-Host "Writing AD CS issues to $Output..."
            try {
                $AllIssues | Select-Object Forest, Technique, Name, DistinguishedName, Issue, Fix | Export-Csv -NoTypeInformation $Output
                Write-Host "$Output created successfully!`n"
            } catch {
                Write-Host 'Ope! Something broke.'
            }
        }
```

### Changes
Uncommented the AllIssues value in the returned hashtable.

After removing the comment, the CSVs are being generated as expected.

I searched existing open issues and could not find any open issue for this, or any note that CSV generation was temporarily disabled.
