### PR TITLE
Clean up quotation marks (#220)

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -174,15 +174,15 @@ function Find-AuditingIssue {
             Technique         = 'DETECT'
             Issue             = "Auditing is not fully enabled on $($_.CAFullName). Important security events may go unnoticed."
             Fix               = @"
-certutil.exe -config `'$($_.CAFullname)`' -setreg `'CA\AuditFilter`' 127
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+certutil.exe -config '$($_.CAFullname)' -setreg CA\AuditFilter 127
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name 'certsvc' | Restart-Service -Force
 }
 "@
             Revert            = @"
-certutil.exe -config $($_.CAFullname) -setreg CA\AuditFilter  $($_.AuditFilter)
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+certutil.exe -config '$($_.CAFullname)' -setreg CA\AuditFilter $($_.AuditFilter)
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name 'certsvc' | Restart-Service -Force
 }
 "@
         }
@@ -282,12 +282,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC1'
@@ -366,20 +366,20 @@ More info:
 '@
                 $Issue.Fix = @"
 # Enable the flag
-certutil -config $CAFullname -setreg CA\InterfaceFlags +IF_ENFORCEENCRYPTICERTREQUEST
+certutil -config '$CAFullname' -setreg CA\InterfaceFlags +IF_ENFORCEENCRYPTICERTREQUEST
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
                 $Issue.Revert = @"
 # Disable the flag
-certutil -config $CAFullname -setreg CA\InterfaceFlags -IF_ENFORCEENCRYPTICERTREQUEST
+certutil -config '$CAFullname' -setreg CA\InterfaceFlags -IF_ENFORCEENCRYPTICERTREQUEST
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
             }
@@ -474,12 +474,12 @@ More info:
 "@
                                 Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                                 Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                                 Technique             = 'ESC13'
@@ -681,12 +681,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC2'
@@ -772,12 +772,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC3'
@@ -865,12 +865,12 @@ More info:
 First, eliminate unused Enrollment Agent templates.
 Then, tightly scope any Enrollment Agent templates that remain and:
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC3'
@@ -996,16 +996,16 @@ More info:
 
 "@
                 Fix                   = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$PreferredOwner')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Revert                = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$($_.nTSecurityDescriptor.Owner)')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Technique             = 'ESC4'
             }
@@ -1050,13 +1050,13 @@ More info:
 
 "@
                     Fix                   = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-Acl -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'
@@ -1231,16 +1231,16 @@ More info:
 
 "@
                 Fix                   = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$PreferredOwner')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Revert                = "
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$($_.nTSecurityDescriptor.Owner)')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL"
                 Technique             = 'ESC5'
             } # end switch ($_.objectClass)
             if ($SkipRisk -eq $false) {
@@ -1331,14 +1331,14 @@ $IssueDetail
 
 "@
                     Fix                   = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and
         ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-Acl -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                     Revert                = '[TODO]'
                     Technique             = 'ESC5'
@@ -1416,20 +1416,20 @@ More info:
 "@
                 $Issue.Fix = @"
 # Disable the flag
-certutil -config $CAFullname -setreg policy\EditFlags -EDITF_ATTRIBUTESUBJECTALTNAME2
+certutil -config '$CAFullname' -setreg policy\EditFlags -EDITF_ATTRIBUTESUBJECTALTNAME2
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
                 $Issue.Revert = @"
 # Enable the flag
-certutil -config $CAFullname -setreg policy\EditFlags +EDITF_ATTRIBUTESUBJECTALTNAME2
+certutil -config '$CAFullname' -setreg policy\EditFlags +EDITF_ATTRIBUTESUBJECTALTNAME2
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
             }
@@ -2453,7 +2453,7 @@ function Invoke-Scans {
         }
         else {
             # To Do: Check for admin and prompt to install features/modules or revert to 'All'.
-            Write-Information "Out-GridView and Out-ConsoleGridView were not found on your system. Defaulting to `'All`'."
+            Write-Information "Out-GridView and Out-ConsoleGridView were not found on your system. Defaulting to 'All'."
             $Scans = 'All'
         }
     }
@@ -3794,11 +3794,11 @@ function Update-ESC1Remediation {
 #   to a smaller group or a single user/service account.
 
 # 2. Remove the ability to submit a SAN (aka disable "Supply in the request").
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Certificate-Name-Flag' = 0}
 
 # 3. Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
 
@@ -3807,11 +3807,11 @@ Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 #   back to $($Issue.IdentityReference).
 
 # 2. Restore the ability to submit a SAN.
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Certificate-Name-Flag' = 1}
 
 # 3. Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
         }
@@ -4381,7 +4381,7 @@ function Invoke-Locksmith {
         [System.Management.Automation.PSCredential]$Credential
     )
 
-    $Version = '2025.1.1'
+    $Version = '2025.1.10'
     $LogoPart1 = @'
     _       _____  _______ _     _ _______ _______ _____ _______ _     _
     |      |     | |       |____/  |______ |  |  |   |      |    |_____|

--- a/Locksmith.psd1
+++ b/Locksmith.psd1
@@ -8,7 +8,7 @@
     FunctionsToExport    = 'Invoke-Locksmith'
     GUID                 = 'b1325b42-8dc4-4f17-aa1f-dcb5984ca14a'
     HelpInfoURI          = 'https://raw.githubusercontent.com/TrimarcJake/Locksmith/main/en-US/'
-    ModuleVersion        = '2025.1.1'
+    ModuleVersion        = '2025.1.10'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Find-AuditingIssue.ps1
+++ b/Private/Find-AuditingIssue.ps1
@@ -48,15 +48,15 @@
             Technique         = 'DETECT'
             Issue             = "Auditing is not fully enabled on $($_.CAFullName). Important security events may go unnoticed."
             Fix               = @"
-certutil.exe -config `'$($_.CAFullname)`' -setreg `'CA\AuditFilter`' 127
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+certutil.exe -config '$($_.CAFullname)' -setreg CA\AuditFilter 127
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name 'certsvc' | Restart-Service -Force
 }
 "@
             Revert            = @"
-certutil.exe -config $($_.CAFullname) -setreg CA\AuditFilter  $($_.AuditFilter)
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+certutil.exe -config '$($_.CAFullname)' -setreg CA\AuditFilter $($_.AuditFilter)
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name 'certsvc' | Restart-Service -Force
 }
 "@
         }

--- a/Private/Find-ESC1.ps1
+++ b/Private/Find-ESC1.ps1
@@ -81,12 +81,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC1'

--- a/Private/Find-ESC11.ps1
+++ b/Private/Find-ESC11.ps1
@@ -59,20 +59,20 @@ More info:
 '@
                 $Issue.Fix = @"
 # Enable the flag
-certutil -config $CAFullname -setreg CA\InterfaceFlags +IF_ENFORCEENCRYPTICERTREQUEST
+certutil -config '$CAFullname' -setreg CA\InterfaceFlags +IF_ENFORCEENCRYPTICERTREQUEST
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
                 $Issue.Revert = @"
 # Disable the flag
-certutil -config $CAFullname -setreg CA\InterfaceFlags -IF_ENFORCEENCRYPTICERTREQUEST
+certutil -config '$CAFullname' -setreg CA\InterfaceFlags -IF_ENFORCEENCRYPTICERTREQUEST
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
             }

--- a/Private/Find-ESC13.ps1
+++ b/Private/Find-ESC13.ps1
@@ -80,12 +80,12 @@ More info:
 "@
                                 Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                                 Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                                 Technique             = 'ESC13'

--- a/Private/Find-ESC2.ps1
+++ b/Private/Find-ESC2.ps1
@@ -82,12 +82,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC2'

--- a/Private/Find-ESC3C1.ps1
+++ b/Private/Find-ESC3C1.ps1
@@ -69,12 +69,12 @@ More info:
 "@
                     Fix                   = @"
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC3'

--- a/Private/Find-ESC3C2.ps1
+++ b/Private/Find-ESC3C2.ps1
@@ -70,12 +70,12 @@ More info:
 First, eliminate unused Enrollment Agent templates.
 Then, tightly scope any Enrollment Agent templates that remain and:
 # Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
                     Revert                = @"
 # Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
                     Technique             = 'ESC3'

--- a/Private/Find-ESC4.ps1
+++ b/Private/Find-ESC4.ps1
@@ -108,16 +108,16 @@ More info:
 
 "@
                 Fix                   = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$PreferredOwner')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Revert                = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$($_.nTSecurityDescriptor.Owner)')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Technique             = 'ESC4'
             }
@@ -161,13 +161,13 @@ More info:
 
 "@
                     Fix                   = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-Acl -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                     Revert                = '[TODO]'
                     Technique             = 'ESC4'

--- a/Private/Find-ESC5.ps1
+++ b/Private/Find-ESC5.ps1
@@ -154,16 +154,16 @@ More info:
 
 "@
                 Fix                   = @"
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$PreferredOwner`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$PreferredOwner')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                 Revert                = "
-`$Owner = New-Object System.Security.Principal.SecurityIdentifier(`'$($_.nTSecurityDescriptor.Owner)`')
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$Owner = New-Object System.Security.Principal.SecurityIdentifier('$($_.nTSecurityDescriptor.Owner)')
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 `$ACL.SetOwner(`$Owner)
-Set-ACL -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL"
+Set-ACL -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL"
                 Technique             = 'ESC5'
             } # end switch ($_.objectClass)
             if ($SkipRisk -eq $false) {
@@ -253,14 +253,14 @@ $IssueDetail
 
 "@
                     Fix                   = @"
-`$ACL = Get-Acl -Path `'AD:$($_.DistinguishedName)`'
+`$ACL = Get-Acl -Path 'AD:$($_.DistinguishedName)'
 foreach ( `$ace in `$ACL.access ) {
     if ( (`$ace.IdentityReference.Value -like '$($Principal.Value)' ) -and
         ( `$ace.ActiveDirectoryRights -notmatch '^ExtendedRight$') ) {
         `$ACL.RemoveAccessRule(`$ace) | Out-Null
     }
 }
-Set-Acl -Path `'AD:$($_.DistinguishedName)`' -AclObject `$ACL
+Set-Acl -Path 'AD:$($_.DistinguishedName)' -AclObject `$ACL
 "@
                     Revert                = '[TODO]'
                     Technique             = 'ESC5'

--- a/Private/Find-ESC6.ps1
+++ b/Private/Find-ESC6.ps1
@@ -62,20 +62,20 @@ More info:
 "@
                 $Issue.Fix = @"
 # Disable the flag
-certutil -config $CAFullname -setreg policy\EditFlags -EDITF_ATTRIBUTESUBJECTALTNAME2
+certutil -config '$CAFullname' -setreg policy\EditFlags -EDITF_ATTRIBUTESUBJECTALTNAME2
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
                 $Issue.Revert = @"
 # Enable the flag
-certutil -config $CAFullname -setreg policy\EditFlags +EDITF_ATTRIBUTESUBJECTALTNAME2
+certutil -config '$CAFullname' -setreg policy\EditFlags +EDITF_ATTRIBUTESUBJECTALTNAME2
 
 # Restart the Certificate Authority service
-Invoke-Command -ComputerName `'$($_.dNSHostName)`' -ScriptBlock {
-    Get-Service -Name `'certsvc`' | Restart-Service -Force
+Invoke-Command -ComputerName '$($_.dNSHostName)' -ScriptBlock {
+    Get-Service -Name certsvc | Restart-Service -Force
 }
 "@
             }

--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -66,7 +66,7 @@ function Invoke-Scans {
             [array]$Scans = ($Dictionary | Select-Object Name, Category, Subcategory | Out-GridView -PassThru -Title $GridViewTitle).Name | Sort-Object -Property Name
         } else {
             # To Do: Check for admin and prompt to install features/modules or revert to 'All'.
-            Write-Information "Out-GridView and Out-ConsoleGridView were not found on your system. Defaulting to `'All`'."
+            Write-Information "Out-GridView and Out-ConsoleGridView were not found on your system. Defaulting to 'All'."
             $Scans = 'All'
         }
     }

--- a/Private/Update-ESC1Remediation.ps1
+++ b/Private/Update-ESC1Remediation.ps1
@@ -61,11 +61,11 @@ function Update-ESC1Remediation {
 #   to a smaller group or a single user/service account.
 
 # 2. Remove the ability to submit a SAN (aka disable "Supply in the request").
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Certificate-Name-Flag' = 0}
 
 # 3. Enable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 "@
 
@@ -74,11 +74,11 @@ Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}
 #   back to $($Issue.IdentityReference).
 
 # 2. Restore the ability to submit a SAN.
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Certificate-Name-Flag' = 1}
 
 # 3. Disable Manager Approval
-`$Object = `'$($_.DistinguishedName)`'
+`$Object = '$($_.DistinguishedName)'
 Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}
 "@
         }


### PR DESCRIPTION
- Added missing single quotes around  Fix and Revert output that may include a space.
- Removed quotes from Fix and Revert output that was unnecessary.
- Cleaned up Fix and Revert attributes that used unnecessary backtick-single quote combo.